### PR TITLE
Bugfixes for Breeding, Gemshop, Gstacks, Storage Chests, Bags

### DIFF
--- a/mysite/idleon_Breeding.py
+++ b/mysite/idleon_Breeding.py
@@ -353,8 +353,8 @@ def setBreedingProgressionTier(inputJSON, progressionTiers):
             "Best IMO: Faster Shiny Pet Lv Up Rate, Bonuses from All Meals, Base Efficiency for All Skills, Base Critter Per Trap",
             "Second best: Drop Rate, Multikill Per Tier, Total Damage, Base WIS, Base STR, Base AGI",
             "Futureproof: W6...?, Infinite Star Signs",
-            "Middle of the pack, helpful to Lv5 at least: Base LUK, Faster Refinery Speed, Higher Artifact Find Chance",
-            "Meh: Lower Minimum Travel Time for Sailing, Sail Captain EXP Gain, Skill EXP",
+            "Middle of the pack, helpful to Lv5 at least: Base LUK, Faster Refinery Speed, Higher Artifact Find Chance, Star Talent Pts",
+            "Meh: Lower Minimum Travel Time for Sailing, Sail Captain EXP Gain, Skill EXP, Tab 1, 2, 3, 4 Talent Pts",
             "Ignorable: Class EXP, Line Width in Lab"]
     else:
         if advice_UnlockedTerritories != "":

--- a/mysite/idleon_Consumables.py
+++ b/mysite/idleon_Consumables.py
@@ -63,14 +63,14 @@ def getBagType(inputBagNumber):
         match inputBagNumber:
             case 0 | 1 | 2 | 3 | 4 | 5 | 7:
                 return "Quest"
-            case 6 | 100 | 101 | 110 :
+            case 6 | 100 | 101 | 110:
                 return "Dropped"
             case 104 | 105 | 106 | 107 | 108 | 109:
                 return "Vendor"
             case 20 | 21 | 22 | 23 | 24 | 25:
                 return "GemShop"
     except:
-        return ("Unknown Bag " + inputBagNumber)
+        return "Unknown Bag " + inputBagNumber
 
 def parseInventoryBagsCount(inputJSON, playerCount, playerNames):
     advice_MissingBags = ""
@@ -122,7 +122,7 @@ def parseInventoryBagsCount(inputJSON, playerCount, playerNames):
             "GemShop":gemshopBags,
             "Total":sumBags
             }
-        if sumBags == currentMaxBagsSum:
+        if sumBags >= currentMaxBagsSum:
             playersWithMaxBags.append(player)
         else:
             playersMissingBags.append(player)
@@ -214,10 +214,10 @@ def parseInventoryBagSlots(inputJSON, playerCount, playerNames):
 
 def parseStorageChests(inputJSON):
     advice_MissingChests = ""
-    currentMaxChestsSum = 40
+    currentMaxChestsSum = 40  # As of v1.91
     usedStorageChests = json.loads(inputJSON['InvStorageUsed'])
     #print(len(usedStorageChests), usedStorageChests)
-    if len(usedStorageChests) != currentMaxChestsSum:
+    if len(usedStorageChests) < currentMaxChestsSum:
         advice_MissingChests = "Collect more storage chests: " + str(len(usedStorageChests)) + "/" + str(currentMaxChestsSum)
     return advice_MissingChests
 

--- a/mysite/idleon_GemShop.py
+++ b/mysite/idleon_GemShop.py
@@ -259,28 +259,28 @@ def setGemShopProgressionTier(inputJSON, progressionTiers, playerCount):
     #progressionTiers[tier][2] = dict recommendedPurchases
     #progressionTiers[tier][3] = str notes
     for recommendedPurchase in progressionTiers[1][2]:
-        if progressionTiers[1][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[1][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_SS += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[1][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[2][2]:
-        if progressionTiers[2][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[2][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_S += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[2][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[3][2]:
-        if progressionTiers[3][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[3][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_A += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[3][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[4][2]:
-        if progressionTiers[4][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[4][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_B += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[4][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[5][2]:
-        if progressionTiers[5][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[5][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_C += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[5][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[6][2]:
-        if progressionTiers[6][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[6][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_D += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[6][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[7][2]:
-        if progressionTiers[7][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[7][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_PracticalMax += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[7][2][recommendedPurchase]) + "), "
     for recommendedPurchase in progressionTiers[8][2]:
-        if progressionTiers[8][2][recommendedPurchase] > gemShopDict[recommendedPurchase]:
+        if progressionTiers[8][2][recommendedPurchase] > float(gemShopDict[recommendedPurchase]):
             advice_TrueMax += getBonusSectionName(recommendedPurchase) + "-" + str(recommendedPurchase) + " (" + str(gemShopDict[recommendedPurchase]) + "/" + str(progressionTiers[8][2][recommendedPurchase]) + "), "
     #Fix up advice statements
     if advice_SS != "":

--- a/mysite/idleon_ProgressionTiers.py
+++ b/mysite/idleon_ProgressionTiers.py
@@ -392,8 +392,8 @@ def setDefaultTiers():
                 "Quest19"  # Previously Tier12
             ],
             "Misc": [
-                "FoodPotMana3", "FoodPotGr3", "FoodPotRe1",  # Previously Tier10
-                "FoodPotRe2"  # Previously Tier11
+                "FoodPotGr3",  # Previously Tier10
+                "FoodPotRe2"   # Previously Tier11
             ],
             "Other Skilling Resources": [
                 "Refinery1",  # Previously Tier11
@@ -493,8 +493,8 @@ def setDefaultTiers():
             "Other Skilling Resources": [
                 "StarfireBar",
                 "Bullet3", "FoodChoppin1"],
-            "Crystal Enemy Drops": ["EquipmentStatues7", "EquipmentStatues3", "EquipmentStatues2", "EquipmentStatues4", "EquipmentStatues14"]
-            #"Misc": ["FoodPotMana3", "FoodPotGr3", "FoodPotRe1"]
+            "Crystal Enemy Drops": ["EquipmentStatues7", "EquipmentStatues3", "EquipmentStatues2", "EquipmentStatues4", "EquipmentStatues14"],
+            "Misc": [],
             #"Vendor Shops": ["FoodHealth9"]
             },
         11: {
@@ -509,7 +509,10 @@ def setDefaultTiers():
             ],
             #"Vendor Shops": ["FoodHealth4", "FoodHealth11"],
             "Misc": [
-                #"FoodPotRe2",
+                #"FoodPotGr3",  # Sold in shops as well as dropped from Sir Stache
+                "FoodPotRe1",  # Technically sold in W1 shop, but so few that it barely matters
+                "FoodPotRe2",
+                "FoodPotMana3",
                 "ButterBar"]
             },
         12: {


### PR DESCRIPTION
### 2024-02-14
### Bugfixes
* General Gstacks- Moved Decent Mana Potion, Small Life Potion, and Average Life Potion out of the Timegated tier. They were put there unintentionally.
* W4 Breeding- Added missed breeding shiny pets: Tab 1,2,3,4, and Star pts.
* Hopefully fixed an issue with reading Gemshop data, which was sometimes being reported as a String instead of Integer.
* General Storage Chests and Inventory Bags: Pre-emptive fix for W6 to not display a message if ABOVE expected amounts, only below.