### PR TITLE
Beanstalk Updates

### DIFF
--- a/mysite/consts.py
+++ b/mysite/consts.py
@@ -3233,6 +3233,7 @@ jade_emporium = [
     "bonus": "Adds 3 new Jewels to unlock at the Jewel Spinner in W4 Town. Or, get one for free every 700 total Lab LV as shown in Rift Skill Mastery."
   }
 ]
+gfood_codes = ["PeanutG", "ButterBar", *[f"FoodG{i}" for i in range(1, 14)]]
 pristineCharmsList: list[str] = [
     "Sparkle Log", "Fruit Rolle", "Glowing Veil", "Cotton Candy", "Sugar Bomb",
     "Gumm Eye", "Bubblegum Law", "Sour Wowzer", "Crystal Comb", "Rock Candy",

--- a/mysite/models/models.py
+++ b/mysite/models/models.py
@@ -16,7 +16,7 @@ from consts import expectedStackables, greenstack_progressionTiers, card_data, m
     artifactsList, guildBonusesList, labBonusesList, lavaFunc, vialsDict, sneakingGemstonesFirstIndex, sneakingGemstonesList, \
     getMoissaniteValue, getGemstoneValue, getGemstonePercent, sneakingGemstonesStatList, stampsDict, stampTypes, marketUpgradeList, \
     achievementsList, forgeUpgradesDict, arcadeBonuses, saltLickList, allMeritsDict, bubblesDict, familyBonusesDict, poBoxDict, equinoxBonusesDict, \
-    maxDreams, dreamsThatUnlockNewBonuses, ceilUpToBase, starsignsDict
+    maxDreams, dreamsThatUnlockNewBonuses, ceilUpToBase, starsignsDict, gfood_codes
 from utils.text_formatting import kebab, getItemCodeName, getItemDisplayName, letterToNumber
 
 def session_singleton(cls):
@@ -1222,11 +1222,11 @@ class Account:
         #World 6
         self.sneaking = {
             "PristineCharms": {},
-            "Gemstones": {}
+            "Gemstones": {},
+            'Beanstalk': {}
         }
-        raw_pristine_charms_list = safe_loads(self.raw_data.get("Ninja", []))
-        if raw_pristine_charms_list:
-            raw_pristine_charms_list = raw_pristine_charms_list[-1]
+        raw_ninja_list = safe_loads(self.raw_data.get("Ninja", []))
+        raw_pristine_charms_list = raw_ninja_list[107] if raw_ninja_list else []
         for pristineCharmIndex, pristineCharmName in enumerate(pristineCharmsList):
             try:
                 self.sneaking["PristineCharms"][pristineCharmName] = bool(raw_pristine_charms_list[pristineCharmIndex])
@@ -1264,6 +1264,21 @@ class Account:
                 )
             except:
                 continue
+
+        raw_beanstalk_list = raw_ninja_list[104] if raw_ninja_list else []
+        for gfoodIndex, gfoodName in enumerate(gfood_codes):
+            try:
+                self.sneaking['Beanstalk'][gfoodName] = {
+                    'Name': getItemDisplayName(gfoodName),
+                    'Beanstacked': raw_beanstalk_list[gfoodIndex] > 0,
+                    'SuperBeanstacked': raw_beanstalk_list[gfoodIndex] > 1,
+                }
+            except:
+                self.sneaking['Beanstalk'][gfoodName] = {
+                    'Name': getItemDisplayName(gfoodName),
+                    'Beanstacked': False,
+                    'SuperBeanstacked': False,
+                }
 
         self.farming = {
             "CropsUnlocked": 0,

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -51,30 +51,30 @@ def section_beanstalk():
 
             gold_foods[food.codename] += food.amount
 
-    foods_to_10k = [
+    foods_to_tier_1 = [
         k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < 10**4
     ]
-    foods_to_deposit_10k = [
-        k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_10k
+    foods_to_deposit_tier_1 = [
+        k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_tier_1
     ]
 
     tier_2_amount_needed_by_golden_food_code: dict[str, int] = dict()
     for golden_food_code in gold_foods:
         # if the golden food's tier 1 goal isn't deposited yet, then use the combined tier 2 goal
         tier_2_goal = COMBINED_TIER_2_GOAL \
-            if golden_food_code in foods_to_deposit_10k \
+            if golden_food_code in foods_to_deposit_tier_1 \
             else BASE_TIER_2_GOAL
 
         tier_2_amount_needed_by_golden_food_code[golden_food_code] = tier_2_goal
 
-    foods_to_100k = [
+    foods_to_tier_2 = [
         k for k, v in beanstalk_status.items() if v < HUNNIT_K and gold_foods[k] < tier_2_amount_needed_by_golden_food_code[k]
     ]
-    foods_to_deposit_100k = [
-        k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_100k
+    foods_to_deposit_tier_2 = [
+        k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_tier_2
     ]
 
-    foods_to_deposit = foods_to_deposit_10k + foods_to_deposit_100k * upgrade_bought
+    foods_to_deposit = foods_to_deposit_tier_1 + foods_to_deposit_tier_2 * upgrade_bought
 
     foods_finished = sum(beanstalk_status.values())
     tier = f"{foods_finished}/{len(gold_foods)*2}"
@@ -87,22 +87,22 @@ def section_beanstalk():
         for codename in foods_to_deposit
     ]
 
-    advice_10k = [
+    advice_tier_1 = [
         Advice(
             label=getItemDisplayName(codename),
             picture_class=getItemDisplayName(codename),
             progression=f"{int(gold_foods[codename]) / TIER_1_GOAL:.02%}",
         )
-        for codename in foods_to_10k
+        for codename in foods_to_tier_1
     ]
 
-    advice_100k = [
+    advice_tier_2 = [
         Advice(
             label=getItemDisplayName(codename),
             picture_class=getItemDisplayName(codename),
             progression=f"{int(gold_foods[codename]) / tier_2_amount_needed_by_golden_food_code[codename]:.02%}",
         )
-        for codename in foods_to_100k
+        for codename in foods_to_tier_2
     ]
 
     group_upgrade = AdviceGroup(
@@ -122,16 +122,16 @@ def section_beanstalk():
         advices=advice_deposit,
     )
 
-    group_10k = AdviceGroup(
+    group_tier_1 = AdviceGroup(
         tier="",
         pre_string="Get 10,000 of these golden foods",
-        advices=advice_10k,
+        advices=advice_tier_1,
     )
 
-    group_100k = AdviceGroup(
+    group_tier_2 = AdviceGroup(
         tier="",
         pre_string="Get another 100,000 of these golden foods",
-        advices=advice_100k,
+        advices=advice_tier_2,
     ) if upgrade_bought else None
 
     if foods_finished == len(gold_foods):
@@ -141,8 +141,8 @@ def section_beanstalk():
 
     groups = [
         group_deposit,
-        group_10k,
-        (group_upgrade if not upgrade_bought else group_100k),
+        group_tier_1,
+        (group_tier_2 if upgrade_bought else group_upgrade),
     ]
 
     return AdviceSection(

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -31,7 +31,7 @@ def section_beanstalk():
         return AdviceSection(
             name="Giant Beanstalk",
             tier="",
-            header='Come back once you\'ve bought the "Gold Food Beanstalk" from the Jade Emporium',
+            header="Come back once you've bought the \"Gold Food Beanstalk\" from the Jade Emporium",
             picture="Jade_Vendor.gif",
             collapse=False,
         )
@@ -50,7 +50,7 @@ def section_beanstalk():
 
             gold_foods[food.codename] += food.amount
 
-    foods_to_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < 10**4]
+    foods_to_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < BEANSTACK_GOAL]
     foods_to_deposit_for_beanstack = [
         k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_beanstack
     ]
@@ -140,12 +140,11 @@ def section_beanstalk():
         else None
     )
 
-    if foods_finished == len(gold_foods):
-        header = (
-            "Well done, Jack! The Golden Goose took an enviably massive dump in your lap. Go pay the giants off! 🍯"
-        )
-    else:
-        header = f"You have upgraded the Beanstalk {tier} times"
+    header = (
+        "Well done, Jack! The Golden Goose took an enviably massive dump in your lap. Go pay the giants off! 🍯"
+        if foods_finished == len(gold_foods)
+        else f"You have upgraded the Beanstalk {tier} times"
+    )
 
     groups = [
         group_deposit,

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -23,12 +23,8 @@ def __get_beanstalk_data(raw):
 
 
 def section_beanstalk():
-    beanstalk_bought = (
-        "Gold Food Beanstalk" in session_data.account.jade_emporium_purchases
-    )
-    upgrade_bought = (
-        "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
-    )
+    beanstalk_bought = "Gold Food Beanstalk" in session_data.account.jade_emporium_purchases
+    upgrade_bought = "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
     beanstalk_data = __get_beanstalk_data(session_data.account.raw_data)
 
     if not (beanstalk_bought or beanstalk_data):
@@ -54,45 +50,23 @@ def section_beanstalk():
 
             gold_foods[food.codename] += food.amount
 
-    foods_to_beanstack = [
-        k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < 10**4
-    ]
-    foods_to_deposit_for_beanstack = [
-        k
-        for k, v in beanstalk_status.items()
-        if v < TEN_K and k not in foods_to_beanstack
-    ]
+    foods_to_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < 10**4]
+    foods_to_deposit_for_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_beanstack]
 
     super_beanstack_progress: dict[str, int] = dict()
     for gold_food_code in gold_foods:
         total_owned = gold_foods[gold_food_code]
 
         # remove 10k from the amount of gold food owned if the first 10k hasn't been collected or deposited yet
-        adjusted_total_owned = (
-            total_owned
-            if gold_food_code
-            not in (foods_to_deposit_for_beanstack + foods_to_beanstack)
-            else total_owned - BEANSTACK_GOAL
-        )
+        adjusted_total_owned = total_owned if gold_food_code not in (foods_to_deposit_for_beanstack + foods_to_beanstack) else total_owned - BEANSTACK_GOAL
 
         # mark progress as 0% if less than 10k is owned
         super_beanstack_progress[gold_food_code] = max(0, adjusted_total_owned)
 
-    foods_to_super_beanstack = [
-        k
-        for k, v in beanstalk_status.items()
-        if v < HUNNIT_K and super_beanstack_progress[k] < SUPER_BEANSTACK_GOAL
-    ]
-    foods_to_deposit_for_super_beanstack = [
-        k
-        for k, v in beanstalk_status.items()
-        if v < HUNNIT_K and k not in foods_to_super_beanstack
-    ]
+    foods_to_super_beanstack = [k for k, v in beanstalk_status.items() if v < HUNNIT_K and super_beanstack_progress[k] < SUPER_BEANSTACK_GOAL]
+    foods_to_deposit_for_super_beanstack = [k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_super_beanstack]
 
-    foods_to_deposit = (
-        foods_to_deposit_for_beanstack
-        + foods_to_deposit_for_super_beanstack * upgrade_bought
-    )
+    foods_to_deposit = foods_to_deposit_for_beanstack + foods_to_deposit_for_super_beanstack * upgrade_bought
 
     foods_finished = sum(beanstalk_status.values())
     tier = f"{foods_finished}/{len(gold_foods)*2}"

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -116,7 +116,7 @@ def section_beanstalk():
 
     group_100k = AdviceGroup(
         tier="",
-        pre_string="Get 100,000 of these golden foods",
+        pre_string="Get another 100,000 of these golden foods",
         advices=advice_100k,
     ) if upgrade_bought else None
 

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -27,7 +27,7 @@ def section_beanstalk():
     upgrade_bought = "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
     beanstalk_data = __get_beanstalk_data(session_data.account.raw_data)
 
-    if not (beanstalk_bought or beanstalk_data):
+    if not (beanstalk_bought and beanstalk_data):
         return AdviceSection(
             name="Giant Beanstalk",
             tier="",
@@ -51,20 +51,30 @@ def section_beanstalk():
             gold_foods[food.codename] += food.amount
 
     foods_to_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < 10**4]
-    foods_to_deposit_for_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_beanstack]
+    foods_to_deposit_for_beanstack = [
+        k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_beanstack
+    ]
 
     super_beanstack_progress: dict[str, int] = dict()
     for gold_food_code in gold_foods:
         total_owned = gold_foods[gold_food_code]
 
         # remove 10k from the amount of gold food owned if the first 10k hasn't been collected or deposited yet
-        adjusted_total_owned = total_owned if gold_food_code not in (foods_to_deposit_for_beanstack + foods_to_beanstack) else total_owned - BEANSTACK_GOAL
+        adjusted_total_owned = (
+            total_owned
+            if gold_food_code not in (foods_to_deposit_for_beanstack + foods_to_beanstack)
+            else total_owned - BEANSTACK_GOAL
+        )
 
         # mark progress as 0% if less than 10k is owned
         super_beanstack_progress[gold_food_code] = max(0, adjusted_total_owned)
 
-    foods_to_super_beanstack = [k for k, v in beanstalk_status.items() if v < HUNNIT_K and super_beanstack_progress[k] < SUPER_BEANSTACK_GOAL]
-    foods_to_deposit_for_super_beanstack = [k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_super_beanstack]
+    foods_to_super_beanstack = [
+        k for k, v in beanstalk_status.items() if v < HUNNIT_K and super_beanstack_progress[k] < SUPER_BEANSTACK_GOAL
+    ]
+    foods_to_deposit_for_super_beanstack = [
+        k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_super_beanstack
+    ]
 
     foods_to_deposit = foods_to_deposit_for_beanstack + foods_to_deposit_for_super_beanstack * upgrade_bought
 
@@ -131,7 +141,9 @@ def section_beanstalk():
     )
 
     if foods_finished == len(gold_foods):
-        header = "Well done, Jack! The Golden Goose took an enviably massive dump in your lap. Go pay the giants off! 🍯"
+        header = (
+            "Well done, Jack! The Golden Goose took an enviably massive dump in your lap. Go pay the giants off! 🍯"
+        )
     else:
         header = f"You have upgraded the Beanstalk {tier} times"
 

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -3,9 +3,6 @@ from models.models import AdviceSection, Advice, AdviceGroup
 from utils.text_formatting import getItemDisplayName
 from flask import g as session_data
 
-TEN_K = 1
-HUNNIT_K = 2
-
 BEANSTACK_GOAL = 10**4
 SUPER_BEANSTACK_GOAL = 10**5
 

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -1,5 +1,5 @@
+from consts import gfood_codes
 from models.models import AdviceSection, Advice, AdviceGroup
-from utils.data_formatting import safe_loads
 from utils.text_formatting import getItemDisplayName
 from flask import g as session_data
 
@@ -10,83 +10,68 @@ BEANSTACK_GOAL = 10**4
 SUPER_BEANSTACK_GOAL = 10**5
 
 
-def __get_ninja_section(raw):
-    default = "[]"
-    return safe_loads(raw.get("Ninja", default))
-
-
-def __get_beanstalk_data(raw):
-    if ninja_section := __get_ninja_section(raw):
-        return ninja_section[-4]
-    else:
-        return []
-
-
 def section_beanstalk():
-    beanstalk_bought = "Gold Food Beanstalk" in session_data.account.jade_emporium_purchases
     upgrade_bought = "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
-    beanstalk_data = __get_beanstalk_data(session_data.account.raw_data)
 
-    if not (beanstalk_bought and beanstalk_data):
+    if "Gold Food Beanstalk" not in session_data.account.jade_emporium_purchases:
         return AdviceSection(
             name="Giant Beanstalk",
             tier="",
             header="Come back once you've bought the \"Gold Food Beanstalk\" from the Jade Emporium",
             picture="Jade_Vendor.gif",
-            collapse=False,
+            collapse=True,
         )
 
-    gfood_codes = ["PeanutG", "ButterBar", *[f"FoodG{i}" for i in range(1, 14)]]
     gold_foods = dict.fromkeys(gfood_codes, 0)
-    beanstalk_status = dict(zip(gfood_codes, beanstalk_data))
 
+    #Assets contains totals from Storage and inventories
     for gfood in gfood_codes:
         gold_foods[gfood] += session_data.account.assets.get(gfood).amount
 
+    #Also include the amounts equipped on characters
     for toon in session_data.account.safe_characters:
         for food in toon.equipment.foods:
-            if food.codename not in beanstalk_status:
-                continue
+            if food.codename in gold_foods:
+                gold_foods[food.codename] += food.amount
 
-            gold_foods[food.codename] += food.amount
-
-    foods_to_beanstack = [k for k, v in beanstalk_status.items() if v < TEN_K and gold_foods[k] < BEANSTACK_GOAL]
-    foods_to_deposit_for_beanstack = [
-        k for k, v in beanstalk_status.items() if v < TEN_K and k not in foods_to_beanstack
-    ]
+    foods_ready_to_deposit = []  #Food ready to deposit, including a tag in the name for 10k or 100k
+    foods_to_beanstack = []  #If food is not already Beanstacked and player has less than required amount (10k)
+    foods_to_deposit_for_beanstack = []  #If food is not already Beanstacked and player has enough to do so
+    for foodName, foodValuesDict in session_data.account.sneaking['Beanstalk'].items():
+        if not foodValuesDict['Beanstacked']:
+            if gold_foods[foodName] < BEANSTACK_GOAL:
+                foods_to_beanstack.append(foodName)
+            else:
+                foods_ready_to_deposit.append(f"{getItemDisplayName(foodName)}: 10k Beanstack")
+                foods_to_deposit_for_beanstack.append(foodName)
 
     super_beanstack_progress: dict[str, int] = dict()
     for gold_food_code in gold_foods:
         total_owned = gold_foods[gold_food_code]
 
-        # remove 10k from the amount of gold food owned if the first 10k hasn't been collected or deposited yet
-        adjusted_total_owned = (
-            total_owned
-            if gold_food_code not in (foods_to_deposit_for_beanstack + foods_to_beanstack)
-            else total_owned - BEANSTACK_GOAL
-        )
+        # remove 10k from the amount of gold food owned if the first 10k hasn't been deposited yet
+        adjusted_total_owned = total_owned if session_data.account.sneaking['Beanstalk'][gold_food_code]['Beanstacked'] else total_owned - BEANSTACK_GOAL
 
         # mark progress as 0% if less than 10k is owned
         super_beanstack_progress[gold_food_code] = max(0, adjusted_total_owned)
 
-    foods_to_super_beanstack = [
-        k for k, v in beanstalk_status.items() if v < HUNNIT_K and super_beanstack_progress[k] < SUPER_BEANSTACK_GOAL
-    ]
-    foods_to_deposit_for_super_beanstack = [
-        k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_super_beanstack
-    ]
+    foods_to_super_beanstack = []  # If food is not already Beanstacked and player has less than required amount (10k)
+    for foodName, foodValuesDict in session_data.account.sneaking['Beanstalk'].items():
+        if not foodValuesDict['SuperBeanstacked']:
+            if super_beanstack_progress[foodName] < SUPER_BEANSTACK_GOAL:
+                foods_to_super_beanstack.append(foodName)
+            else:
+                foods_ready_to_deposit.append(f"{getItemDisplayName(foodName)}: 100k Super Beanstack")
 
-    foods_to_deposit = foods_to_deposit_for_beanstack + foods_to_deposit_for_super_beanstack * upgrade_bought
-
-    foods_finished = sum(beanstalk_status.values())
+    foods_finished = sum([v['Beanstacked'] for v in session_data.account.sneaking['Beanstalk'].values()])
     tier = f"{foods_finished}/{len(gold_foods)*2}"
 
     advice_deposit = [
         Advice(
-            label=getItemDisplayName(codename),
-            picture_class=getItemDisplayName(codename),
+            label=foodname,
+            picture_class=foodname.split(":")[0],
         )
-        for codename in foods_to_deposit
+        for foodname in foods_ready_to_deposit
     ]
 
     advice_beanstack = [
@@ -120,20 +105,20 @@ def section_beanstalk():
 
     group_deposit = AdviceGroup(
         tier="",
-        pre_string="Deposit these golden foods",
+        pre_string="Golden Foods ready for deposit",
         advices=advice_deposit,
     )
 
     group_beanstack = AdviceGroup(
         tier="",
-        pre_string="Get 10,000 of these golden foods",
+        pre_string="Collect 10,000 of these golden foods",
         advices=advice_beanstack,
     )
 
     group_super_beanstack = (
         AdviceGroup(
             tier="",
-            pre_string="Get another 100,000 of these golden foods",
+            pre_string="Collect another 100,000 of these golden foods",
             advices=advice_super_beanstack,
         )
         if upgrade_bought

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -24,19 +24,19 @@ def section_beanstalk():
 
     gold_foods = dict.fromkeys(gfood_codes, 0)
 
-    #Assets contains totals from Storage and inventories
+    # Assets contains totals from Storage and inventories
     for gfood in gfood_codes:
         gold_foods[gfood] += session_data.account.assets.get(gfood).amount
 
-    #Also include the amounts equipped on characters
+    # Also include the amounts equipped on characters
     for toon in session_data.account.safe_characters:
         for food in toon.equipment.foods:
             if food.codename in gold_foods:
                 gold_foods[food.codename] += food.amount
 
-    foods_ready_to_deposit = []  #Food ready to deposit, including a tag in the name for 10k or 100k
-    foods_to_beanstack = []  #If food is not already Beanstacked and player has less than required amount (10k)
-    foods_to_deposit_for_beanstack = []  #If food is not already Beanstacked and player has enough to do so
+    foods_ready_to_deposit = []  # Food ready to deposit, including a tag in the name for 10k or 100k
+    foods_to_beanstack = []  # If food is not already Beanstacked and player has less than required amount (10k)
+    foods_to_deposit_for_beanstack = []  # If food is not already Beanstacked and player has enough to do so
     for foodName, foodValuesDict in session_data.account.sneaking['Beanstalk'].items():
         if not foodValuesDict['Beanstacked']:
             if gold_foods[foodName] < BEANSTACK_GOAL:
@@ -46,11 +46,13 @@ def section_beanstalk():
                 foods_to_deposit_for_beanstack.append(foodName)
 
     super_beanstack_progress: dict[str, int] = dict()
-    for gold_food_code in gold_foods:
-        total_owned = gold_foods[gold_food_code]
-
-        # remove 10k from the amount of gold food owned if the first 10k hasn't been deposited yet
-        adjusted_total_owned = total_owned if session_data.account.sneaking['Beanstalk'][gold_food_code]['Beanstacked'] else total_owned - BEANSTACK_GOAL
+    for gold_food_code, total_owned in gold_foods.items():
+        # Remove 10k from the amount of gold food owned if the first 10k hasn't been deposited yet
+        adjusted_total_owned = (
+            total_owned
+            if session_data.account.sneaking['Beanstalk'][gold_food_code]['Beanstacked']
+            else total_owned - BEANSTACK_GOAL
+        )
 
         # mark progress as 0% if less than 10k is owned
         super_beanstack_progress[gold_food_code] = max(0, adjusted_total_owned)

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -62,7 +62,7 @@ def section_beanstalk():
             else:
                 foods_ready_to_deposit.append(f"{getItemDisplayName(foodName)}: 100k Super Beanstack")
 
-    foods_finished = sum([v['Beanstacked'] for v in session_data.account.sneaking['Beanstalk'].values()])
+    foods_finished = sum([v['Beanstacked'] + v['SuperBeanstacked'] for v in session_data.account.sneaking['Beanstalk'].values()])
     tier = f"{foods_finished}/{len(gold_foods)*2}"
 
     advice_deposit = [
@@ -93,7 +93,7 @@ def section_beanstalk():
 
     group_upgrade = AdviceGroup(
         tier="",
-        pre_string="Upgrade the Beanstalk to upgrade foods further",
+        pre_string="Upgrade the Beanstalk to enhance Golden Food beanstacks further",
         advices=[
             Advice(
                 label='Buy "Supersized Gold Beanstacking" from the Jade Emporium',
@@ -110,14 +110,14 @@ def section_beanstalk():
 
     group_beanstack = AdviceGroup(
         tier="",
-        pre_string="Collect 10,000 of these golden foods",
+        pre_string="Collect 10,000 of these Golden Foods",
         advices=advice_beanstack,
     )
 
     group_super_beanstack = (
         AdviceGroup(
             tier="",
-            pre_string="Collect another 100,000 of these golden foods",
+            pre_string="Collect another 100,000 of these Golden Foods",
             advices=advice_super_beanstack,
         )
         if upgrade_bought

--- a/mysite/w6/beanstalk.py
+++ b/mysite/w6/beanstalk.py
@@ -6,7 +6,7 @@ from flask import g as session_data
 TEN_K = 1
 HUNNIT_K = 2
 
-TIER_1_GOAL = 10**4
+TIER_1_GOAL = 10**4  # maybe rename these to beanstack and super beanstack
 BASE_TIER_2_GOAL = 10**5
 COMBINED_TIER_2_GOAL = TIER_1_GOAL + BASE_TIER_2_GOAL
 
@@ -24,17 +24,21 @@ def __get_beanstalk_data(raw):
 
 
 def section_beanstalk():
-    beanstalk_bought = "Gold Food Beanstalk" in session_data.account.jade_emporium_purchases
-    upgrade_bought = "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
+    beanstalk_bought = (
+        "Gold Food Beanstalk" in session_data.account.jade_emporium_purchases
+    )
+    upgrade_bought = (
+        "Supersized Gold Beanstacking" in session_data.account.jade_emporium_purchases
+    )
     beanstalk_data = __get_beanstalk_data(session_data.account.raw_data)
 
     if not (beanstalk_bought or beanstalk_data):
         return AdviceSection(
             name="Giant Beanstalk",
             tier="",
-            header="Come back once you've bought the \"Gold Food Beanstalk\" from the Jade Emporium",
+            header='Come back once you\'ve bought the "Gold Food Beanstalk" from the Jade Emporium',
             picture="Jade_Vendor.gif",
-            collapse=False
+            collapse=False,
         )
 
     gfood_codes = ["PeanutG", "ButterBar", *[f"FoodG{i}" for i in range(1, 14)]]
@@ -61,20 +65,28 @@ def section_beanstalk():
     tier_2_amount_needed_by_golden_food_code: dict[str, int] = dict()
     for golden_food_code in gold_foods:
         # if the golden food's tier 1 goal isn't deposited yet, then use the combined tier 2 goal
-        tier_2_goal = COMBINED_TIER_2_GOAL \
-            if golden_food_code in foods_to_deposit_tier_1 \
+        tier_2_goal = (
+            COMBINED_TIER_2_GOAL
+            if golden_food_code in foods_to_deposit_tier_1
             else BASE_TIER_2_GOAL
+        )
 
         tier_2_amount_needed_by_golden_food_code[golden_food_code] = tier_2_goal
 
     foods_to_tier_2 = [
-        k for k, v in beanstalk_status.items() if v < HUNNIT_K and gold_foods[k] < tier_2_amount_needed_by_golden_food_code[k]
+        k
+        for k, v in beanstalk_status.items()
+        if v < HUNNIT_K and gold_foods[k] < tier_2_amount_needed_by_golden_food_code[k]
     ]
     foods_to_deposit_tier_2 = [
-        k for k, v in beanstalk_status.items() if v < HUNNIT_K and k not in foods_to_tier_2
+        k
+        for k, v in beanstalk_status.items()
+        if v < HUNNIT_K and k not in foods_to_tier_2
     ]
 
-    foods_to_deposit = foods_to_deposit_tier_1 + foods_to_deposit_tier_2 * upgrade_bought
+    foods_to_deposit = (
+        foods_to_deposit_tier_1 + foods_to_deposit_tier_2 * upgrade_bought
+    )
 
     foods_finished = sum(beanstalk_status.values())
     tier = f"{foods_finished}/{len(gold_foods)*2}"
@@ -110,10 +122,10 @@ def section_beanstalk():
         pre_string="Upgrade the Beanstalk to upgrade foods further",
         advices=[
             Advice(
-                label="Buy \"Supersized Gold Beanstacking\" from the Jade Emporium",
-                picture_class="supersized-gold-beanstacking"
+                label='Buy "Supersized Gold Beanstacking" from the Jade Emporium',
+                picture_class="supersized-gold-beanstacking",
             )
-        ]
+        ],
     )
 
     group_deposit = AdviceGroup(
@@ -128,11 +140,15 @@ def section_beanstalk():
         advices=advice_tier_1,
     )
 
-    group_tier_2 = AdviceGroup(
-        tier="",
-        pre_string="Get another 100,000 of these golden foods",
-        advices=advice_tier_2,
-    ) if upgrade_bought else None
+    group_tier_2 = (
+        AdviceGroup(
+            tier="",
+            pre_string="Get another 100,000 of these golden foods",
+            advices=advice_tier_2,
+        )
+        if upgrade_bought
+        else None
+    )
 
     if foods_finished == len(gold_foods):
         header = "Well done, Jack! The Golden Goose took an enviably massive dump in your lap. Go pay the giants off! 🍯"
@@ -150,5 +166,5 @@ def section_beanstalk():
         tier=tier,
         header=header,
         picture="Beanstalk.png",
-        groups=groups
+        groups=groups,
     )


### PR DESCRIPTION
## Updated Super Beanstack Progress
Made it so that Super Beanstack requires will remove 10k from your progress if you haven't collected or deposited the first 10k of that type yet.

### Scenario 1: 101k Golden Food Owned (10k non-deposited)
Here's what it would look like if you owned 101k golden bread and didn't deposit the first 10k yet:
<img width="1496" alt="image" src="https://github.com/TwoSpookyBoos/IdleOnAutoReviewBot/assets/26943377/2fc00b86-4632-4b95-b237-7a31da820f92">
- Removed from the OG beanstack list
- Added to the deposit list
- Still in the Super Beanstack list, but progression bar displays the % as if you only owned 91k golden bread

### Scenario 2: 131k Golden Food Owned (10k non-deposited)
Here's what it would look like if you owned 131k golden bread and didn't deposit the first 10k yet:
<img width="1489" alt="image" src="https://github.com/TwoSpookyBoos/IdleOnAutoReviewBot/assets/26943377/92dca9f8-f1d8-4556-a073-475a4d61b8e9">
- Removed from both OG and Super Beanstack lists
- Added to the deposit list twice

### Scenario 3: Less than 10k Golden Food Owned
Here's what the progression bar looks like if you haven't collected 10k golden cakes:
<img width="1496" alt="image" src="https://github.com/TwoSpookyBoos/IdleOnAutoReviewBot/assets/26943377/7c3b0a6a-5bd8-4b2d-9e59-0108cf914c7b">
- Progression bar for Super Beanstacking is 0% despite owning some. This is because the progress bar must fill up on the OG Beanstack bar first before starting to fill up the Super Beanstack bar.

## Minor edits
- Updated the tier 2 list to say "Get another 100k..." from "Get 100k..." to emphasize that you'll need 100k more (so 110k in total)
