### PR TITLE
Dev_environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,11 +12,7 @@
 			]
 		}
 	},
-	"workspaceFolder": "mysite",
 	"forwardPorts": [5000],
-	"postCreateCommand": [
-		"pip install --upgrade pip setuptools wheel",
-		"pip install -r mysite/requirements.txt"
-	]
+	"postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh"
 	
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.debugpy"
+			]
+		}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [5000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip install --upgrade pip setuptools wheel; pip install -r requirements.txt"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,6 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Python 3",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
 	"customizations": {
 		"vscode": {
@@ -13,19 +12,11 @@
 			]
 		}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"workspaceFolder": "mysite",
 	"forwardPorts": [5000],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install --upgrade pip setuptools wheel; pip install -r requirements.txt"
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"postCreateCommand": [
+		"pip install --upgrade pip setuptools wheel",
+		"pip install -r mysite/requirements.txt"
+	]
+	
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+pip install --upgrade pip setuptools wheel
+pip install -r mysite/requirements/dev.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug app",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flask",
+            "cwd": "${workspaceFolder}/mysite",
+            "console": "internalConsole",
+            "env": {
+                "PYTHONUNBUFFERED": "1",
+                "FLASK_APP": "flask_app:app",
+                "FLASK_ENV": "development",
+                "FLASK_DEBUG": "1",
+                "FLASK_RUN_PORT": "5000"
+            },
+            "args": [
+                "run"
+            ],
+            "jinja": true,
+            "autoStartBrowser": false
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ venv_dir="<venv/dir/name/here>"
 python -m venv "$venv_dir"
 source "$venv_dir"/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install -r requirements.txt
+pip install -r mysite/requirements/dev.txt
 ```
 #### Windows:
 ``` powershell
@@ -33,7 +33,7 @@ $venv_dir = "<venv/dir/name/here>"
 python -m venv "$venv_dir"
 "$venv_dir"/Scripts/Activate.ps1
 pip install --upgrade pip setuptools wheel
-pip install -r requirements.txt
+pip install -r mysite/requirements/dev.txt
 ```
 <hr/>
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ http://ieautoreview-scoli.pythonanywhere.com/
 _This tool is created and tested using Python 3.11._
 <hr/>
 
+### Using github codespaces
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TwoSpookyBoos/IdleOnAutoReviewBot)
+
+Click the button above, wait for the environment to be created
+
+### The manual way
 Create and enable the virtual environment, and install the required packages.  
 >Note that `coloredlogs` is commented in `mysite/requirements.txt`, as it doesn't work with the PythonAnywhere site. It's still needed for dev work though, so make sure it gets installed too, by uncommenting it. 
 
@@ -28,11 +34,16 @@ python -m venv "$venv_dir"
 "$venv_dir"/Scripts/Activate.ps1
 pip install --upgrade pip setuptools wheel
 pip install -r requirements.txt
-
 ```
 <hr/>
 
-### Run
+## Run
+
+### Using github codespaces
+Hit `Ctrl+Maj+D` or navigate to the debug tab, and run the included config.
+A popup will give you a link to the now hosted app
+
+### The manual way
 
 To run the app, run:
 #### Unix/MacOS:
@@ -56,7 +67,7 @@ python -m flask run
 or, if you're using PyCharm, run one of the two saved run configurations.
 <hr/>
 
-### Test
+## Test
 
 To run tests, run:
 ``` bash

--- a/mysite/requirements.txt
+++ b/mysite/requirements.txt
@@ -1,9 +1,1 @@
-flask
-requests
-#coloredlogs
-# Note: colordlogs is needed for dev, but not for the PythonAnywhere deployment. Uncomment the line above to install it.
-ua-parser
-babel
-pyyaml
-libsass
-pytest
+-r requirements/prod.txt

--- a/mysite/requirements/common.txt
+++ b/mysite/requirements/common.txt
@@ -1,0 +1,7 @@
+flask
+requests
+ua-parser
+babel
+pyyaml
+libsass
+pytest

--- a/mysite/requirements/dev.txt
+++ b/mysite/requirements/dev.txt
@@ -1,0 +1,2 @@
+-r common.txt
+coloredlogs

--- a/mysite/requirements/prod.txt
+++ b/mysite/requirements/prod.txt
@@ -1,0 +1,1 @@
+-r common.txt

--- a/mysite/requirements/prod.txt
+++ b/mysite/requirements/prod.txt
@@ -1,1 +1,0 @@
--r common.txt


### PR DESCRIPTION
It does change a little bit requirement.txt

I didn't move the existing one for compatibility reasons, but you should be able to select `requirement/prod.txt` in PythonAnywhere to select the requirements without coloredlogs

If it works for you, we can then remove the requirement.txt and update the readme to run `pip install -r mysite/requirement/dev.txt`