### PR TITLE
Adjust safety level display a little

### DIFF
--- a/mysite/w5/gaming.py
+++ b/mysite/w5/gaming.py
@@ -217,12 +217,22 @@ def getSnailInformationGroup() -> AdviceGroup:
             ))
 
             # TODO: This doesn't explain what the "safety limit" means!
-            for target_confidence in TARGET_CONFIDENCE_LEVELS:
+            for target_idx, target_confidence in enumerate(TARGET_CONFIDENCE_LEVELS):
                 mail_needed, overall_chance = safety_thresholds[level, target_confidence]
+                if mail_needed == 3 and target_idx+1 < len(TARGET_CONFIDENCE_LEVELS):
+                    if safety_thresholds[level, TARGET_CONFIDENCE_LEVELS[target_idx+1]][0] == 3:
+                        # Skip "duplicate" safety level info, that is cases where no extra mail is needed
+                        # and no extra mail is needed for a higher confidence level as well.
+                        continue
+
+                progression = 0
+                if level == snail_data['SnailRank'] and snail_data['Encouragements'] >= num_encourage:
+                    progression = floored_envelopes
+
                 snail_AdviceDict[subgroupName].append(Advice(
-                    label=f"{mail_needed} spare mail needed for {target_confidence:.1%} safety",
+                    label=f"{mail_needed} mail needed for {target_confidence:.1%} safety",
                     picture_class='snail-envelope',
-                    progression=floored_envelopes,
+                    progression=progression,
                     goal=mail_needed
                 ))
 

--- a/mysite/w5/gaming.py
+++ b/mysite/w5/gaming.py
@@ -216,7 +216,6 @@ def getSnailInformationGroup() -> AdviceGroup:
                 goal=num_encourage
             ))
 
-            # TODO: This doesn't explain what the "safety limit" means!
             for target_idx, target_confidence in enumerate(TARGET_CONFIDENCE_LEVELS):
                 mail_needed, overall_chance = safety_thresholds[level, target_confidence]
                 if mail_needed == 3 and target_idx+1 < len(TARGET_CONFIDENCE_LEVELS):

--- a/mysite/w5/gaming.py
+++ b/mysite/w5/gaming.py
@@ -224,16 +224,16 @@ def getSnailInformationGroup() -> AdviceGroup:
                         # and no extra mail is needed for a higher confidence level as well.
                         continue
 
-                progression = 0
-                if level == snail_data['SnailRank'] and snail_data['Encouragements'] >= num_encourage:
-                    progression = floored_envelopes
+                advice_construction_dict = {
+                    'label': f"{mail_needed} mail before clicking Level Up for {target_confidence:.1%} safety",
+                    'picture_class': 'snail-envelope'
+                }
 
-                snail_AdviceDict[subgroupName].append(Advice(
-                    label=f"{mail_needed} mail needed for {target_confidence:.1%} safety",
-                    picture_class='snail-envelope',
-                    progression=progression,
-                    goal=mail_needed
-                ))
+                if level == snail_data['SnailRank'] and snail_data['Encouragements'] >= num_encourage:
+                    advice_construction_dict['progression'] = floored_envelopes
+                    advice_construction_dict['goal'] = mail_needed
+
+                snail_AdviceDict[subgroupName].append(Advice(**advice_construction_dict))
 
     snail_AdviceGroup = AdviceGroup(
         tier='',

--- a/mysite/w5/gaming.py
+++ b/mysite/w5/gaming.py
@@ -219,7 +219,7 @@ def getSnailInformationGroup() -> AdviceGroup:
             for target_idx, target_confidence in enumerate(TARGET_CONFIDENCE_LEVELS):
                 mail_needed, overall_chance = safety_thresholds[level, target_confidence]
                 if mail_needed == 3 and target_idx+1 < len(TARGET_CONFIDENCE_LEVELS):
-                    if safety_thresholds[level, TARGET_CONFIDENCE_LEVELS[target_idx+1]][0] == 3:
+                    if overall_chance >= TARGET_CONFIDENCE_LEVELS[target_idx+1]:
                         # Skip "duplicate" safety level info, that is cases where no extra mail is needed
                         # and no extra mail is needed for a higher confidence level as well.
                         continue


### PR DESCRIPTION
- Skip "3 mail" safety levels if 3 mail also supports a higher confidence level
- Only report safety level progress for the current snail rank, and only if the encouragements are complete