### PR TITLE
Beta 2025-04-11 (#240) (#241)

### DIFF
--- a/changelog/CHANGELOG
+++ b/changelog/CHANGELOG
@@ -1,3 +1,4 @@
+2025-04-14: Library now grouped by Priority. More Statues in Gstack difficulty groups. Overwhelmed Mode setting renamed.
 2025-04-07: Summoning Doubler expansion, GStack info tiers, few other litle improvements
 2025-04-03: v2.35 changes and additions to Cards, Inventory, Storage, Greenstacks, Event Shop, Arcade, and Slab
 2025-03-31: Testing: Toolbox profile fetching

--- a/mysite/consts.py
+++ b/mysite/consts.py
@@ -285,6 +285,7 @@ greenstack_item_difficulty_groups = {
                 "EquipmentStatues1", "EquipmentStatues5",  #Power and Health statues are still more common than W2 statues
                 "EquipmentStatues10", "EquipmentStatues12", "EquipmentStatues13", "EquipmentStatues8", "EquipmentStatues11",  #W2 statues
                 "EquipmentStatues18",  #W3 EhExPee statue
+                "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
                 "rtt0",
                 "StoneA1", "StoneW1", "StoneZ1", "StoneT1",
                 "StoneZ2", "StoneT2",
@@ -297,18 +298,22 @@ greenstack_item_difficulty_groups = {
             ],
             "Rare Drops": [
                 "FoodPotMana3", "ButterBar", "EquipmentStatues9", "OilBarrel2", "FoodPotRe2", "FoodPotGr3", "FoodHealth9",
+                'EquipmentStatues29',  # Villager Statues from Caverns
             ],
         },
         14: {
             "Crystal Enemy Drops": [
-                "StoneW2", 'ResetFrag', "SilverPen"],  #"StoneA2",],
+                "StoneW2", 'ResetFrag', "SilverPen",
+                "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25",  # W5 Statues
+            ],  #"StoneA2",],
             "Other Skilling Resources": [
                 "FoodTrapping1", "FoodWorship1",
                 "Critter1A", "Critter2A", "Critter3A", "Critter4A", "Critter5A", "Critter6A", "Critter7A", "Critter8A", "Critter9A", "Critter10A", "Critter11A",
                 "Ladle",
             ],
             "Rare Drops": [
-                "DesertC2b", "EfauntDrop1"
+                "DesertC2b", "EfauntDrop1",
+                'EquipmentStatues30',  # Dragon Warrior Statues from Caverns
             ]
         },
     }
@@ -496,18 +501,20 @@ stamps_progressionTiers = {
             'Drippy Drop Stamp': 50,
             'Pickaxe Stamp': 55, 'Hatchet Stamp': 55, 'Card Stamp': 50
         },
-        "Optional": ["Saw Stamp", "Agile Stamp", "Book Stamp", "Smart Dirt Stamp", "High IQ Lumber Stamp", "Fishhead Stamp",
-                    "Polearm Stamp", "Biblio Stamp"]
+        "Optional": [
+            "Saw Stamp", "Agile Stamp", "Book Stamp", "Smart Dirt Stamp", "High IQ Lumber Stamp", "Fishhead Stamp",
+            "Polearm Stamp", "Biblio Stamp"
+        ]
     }},
     13: {"TotalStampLevels": 2500, "Stamps": {
-        "Skill": ["Banked Pts Stamp", "Nest Eggs Stamp", "Lab Tube Stamp", "Ladle Stamp", "Sailboat Stamp"],
+        "Skill": ["Banked Pts Stamp", "Nest Eggs Stamp", "Ladle Stamp", "Sailboat Stamp"],
         "Misc": ["Refinery"],
         "Specific": {
             'Matty Bag Stamp': 100, 'Crystallin': 60,
             'Pickaxe Stamp': 65, 'Hatchet Stamp': 65, 'Card Stamp': 100,
         },
         "Optional": ["Stat Graph Stamp", "Brainstew Stamps", "Arcane Stamp", "Fly Intel Stamp", "Holy Mackerel Stamp", "Talent II Stamp",
-                     "Gilded Axe Stamp", "Avast Yar Stamp", "Blackheart Stamp", "DNA Stamp"]
+                     "Gilded Axe Stamp", "Avast Yar Stamp", "Blackheart Stamp", "Lab Tube Stamp", "DNA Stamp"]
     }},
     14: {"TotalStampLevels": 4000, "Stamps": {
         "Combat": ["Sashe Sidestamp"],
@@ -1878,7 +1885,7 @@ farming_progressionTiers = {
 #If you add a new switch here, you need to also add a default in \static\scripts\main.js:defaults
 switches = [
     {
-        "label": "Overwhelmed Mode",
+        "label": "Display lowest rated sections only",
         "name": "overwhelmed",
         "true": "",
         "false": "",
@@ -2035,7 +2042,9 @@ expectedStackables = {
         "rtt0", "StoneZ1", "StoneT1", "StoneW1", "StoneA1",  #W1 Slow drops = Town TP + Stones
         "StoneT2", "StoneZ2",  "StoneW2",  #"StoneA2", # W2 upgrade stones and Mystery2
         "PureWater", "EquipmentStatues18",  #W3 Slow drops = Distilled Water + EhExPee Statue
-        "FoodG9",  #W5 Slow drops = Golden W5 Sammy
+        "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
+        "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25", "FoodG9",  #W5 Slow drops = Golden W5 Sammy + Statues
+
         "FoodG11", "FoodG12"
     ],
     "Printable Skilling Resources": [
@@ -2088,7 +2097,8 @@ expectedStackables = {
         "DesertC2b",  # Ghost, 1 in 2k
         "Quest78",  # Equinox Mirror
         "EfauntDrop1",  # Basic Efaunt material
-        "Key2", "Key3"  # Efaunt and Chizoar keys
+        "Key2", "Key3",  # Efaunt and Chizoar keys
+        'EquipmentStatues29', 'EquipmentStatues30',  # Villager and Dragon Warrior statues from Caverns
     ],
     "Cheater": [
         "Sewers1b", "TreeInterior1b", "BabaYagaETC", "JobApplication",  # W1 Rare Drops
@@ -2118,8 +2128,6 @@ expectedStackables = {
         "FoodHealth8", "Quest69", "Quest74",  # Unobtainables
         "EquipmentStatues6", "EquipmentStatues15",  # Kachow and Bullseye
         "EquipmentStatues16", "EquipmentStatues17", "EquipmentStatues19",  # W3 Statues
-        "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
-        "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25",  # W5 Statues
         "FoodG1", "FoodG2", "FoodG3", "FoodG4", "FoodG5", "FoodG6", "FoodG7", "FoodG8", "FoodG10",  # Gold Foods
         "ResetCompleted", "ResetCompletedS", "ClassSwap",
         "ClassSwapB", "ResetBox",
@@ -3319,8 +3327,8 @@ expected_talentsDict = {
 hardcap_symbols = 280  #Last verified as of v2.23
 hardcap_enhancement_eclipse = 250  #Lava might add more in the future, but there are no bonuses above 250 in v2.10
 librarySubgroupTiers = [
-    '', 'Skilling - High Priority', 'Skilling - Medium Priority', 'Skilling - Low Priority', 'Skilling - Lowest Priority',
-    'Combat - High Priority', 'Combat - Medium Priority', 'Combat - Low Priority', 'ALL Unmaxed Talents'
+    'Account Wide Priorities', 'Skilling - High Priority', 'Skilling - Medium Priority', 'Skilling - Low Priority', 'Skilling - Lowest Priority',
+    'Combat - High Priority', 'Combat - Medium Priority', 'Combat - Low Priority', 'ALL Unmaxed Talents', 'VIP'
 ]  #Why is there a placeholder in [0] again?
 skill_talentsDict = {
     # Optimal is an optional list for calculating library.getJeapordyGoal
@@ -4514,7 +4522,7 @@ event_points_shop_dict = {
     'Ribbon Connoisseur': {'Cost': 35, 'Code': 'm', 'Description': 'Get +3 daily Ribbons', 'Image': 'event-shop-13'},
     'Golden Square': {'Cost': 23, 'Code': 'n', 'Description': 'Get +1 Trimmed Constrution slot', 'Image': 'event-shop-14'},
     'Summoning Star': {'Cost': 30, 'Code': 'o', 'Description': 'Get +10 Summoning Doublers', 'Image': 'event-shop-15'},
-    'Royal Vote Button': {'Cost': 25, 'Code': 'p', 'Description': "Get +30% higher Ballot Bonus Multi from Voting", 'Image': 'event-shop-16'},
+    'Royal Vote Button': {'Cost': 25, 'Code': 'p', 'Description': "Get +13% higher Ballot Bonus Multi from Voting", 'Image': 'event-shop-16'},
 }
 
 ###WORLD 2 CONSTS###
@@ -5265,10 +5273,15 @@ buildingsDict = {
     25: {'Name': 'Undead Shrine', 'Image': 'undead-shrine', 'BaseMaxLevel': 100, 'Type': 'Shrine', 'ValueBase': 5, 'ValueIncrement': 1},
     26: {'Name': 'Primordial Shrine', 'Image': 'primordial-shrine', 'BaseMaxLevel': 100, 'Type': 'Shrine', 'ValueBase': 1, 'ValueIncrement': 0.1},
 }
-buildingsTowerMaxLevel = 140
-shrinesList: list[str] = [
-    "Woodular Shrine", "Isaccian Shrine", "Crystal Shrine", "Pantheon Shrine", "Clover Shrine", "Summereading Shrine", "Crescent Shrine", "Undead Shrine", "Primordial Shrine"
-]
+# buildings_utilities = [buildingValuesDict['Name'] for buildingName, buildingValuesDict in buildingsDict.items() if buildingValuesDict['Type'] == 'Utility']
+buildings_towers = [buildingValuesDict['Name'] for buildingName, buildingValuesDict in buildingsDict.items() if buildingValuesDict['Type'] == 'Tower']
+buildingsTowerMaxLevel = (
+    50  #Base
+    + 30  #2.5 Cons Mastery
+    + 60  #2 per level times 30 max levels of Atom Collider - Carbon
+    + 100  #Cavern 14 - Gambit - Bonus Index 9
+)  #As of v2.35
+buildings_shrines: list[str] = [buildingValuesDict['Name'] for buildingName, buildingValuesDict in buildingsDict.items() if buildingValuesDict['Type'] == 'Shrine']
 #AtomInfo in code. Last pulled 2.11 Kanga
 atomsList: list[list] = [
     ["Hydrogen - Stamp Decreaser", 1, 1.35, 2, 1, "Every day you log in, the resource cost to upgrade a stamp's max lv decreases by {% up to a max of 90%. This reduction resets back to 0% when upgrading any stamp max lv."],

--- a/mysite/general/pinchy.py
+++ b/mysite/general/pinchy.py
@@ -180,9 +180,9 @@ class Placements(dict):
         #               W1   W2          W3              W4              W5              W6              W7              Max    True    Placeholder
         COMBAT_LEVELS: [0,   3, 7, 8,    10, 14, 15,     16, 17, 18,     19, 21, 23,     24, 25, 27,     28, 29, 30,     32,    true_max_tiers[COMBAT_LEVELS], 99],
         SECRET_CLASS_PATH:[0,0, 0, 0,    0,  0,  0,      0,  1,  1,      2,  3,  3,      3,  3,  3,      3,  3,  3,      3,     true_max_tiers[SECRET_CLASS_PATH], 99],
-        ACHIEVEMENTS:  [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      1,  1,  1,      2,  3,  4,      4,     true_max_tiers[ACHIEVEMENTS], 99],
+        ACHIEVEMENTS:  [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      1,  1,  1,      1,  2,  3,      4,     true_max_tiers[ACHIEVEMENTS], 99],
         GSTACKS:       [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  0,  0,      1,  2,  2,      2,  3,  3,      3,     true_max_tiers[GSTACKS], 99],
-        STAMPS:        [0,   1, 2, 3,    4,  5,  6,      7,  8,  9,      10, 11, 12,     13, 14, 15,     16, 17, 18,     20,    true_max_tiers[STAMPS], 99],
+        STAMPS:        [0,   1, 2, 2,    3,  4,  5,      6,  7,  8,      9, 10, 11,     12, 13, 14,     15, 16, 17,     20,    true_max_tiers[STAMPS], 99],
         BRIBES:        [0,   1, 1, 1,    2,  2,  2,      3,  3,  3,      4,  4,  4,      4,  5,  5,      5,  5,  5,      6,     true_max_tiers[BRIBES], 99],
         SMITHING:      [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      1,  2,  2,      3,  4,  5,      6,     true_max_tiers[SMITHING], 99],
         STATUES:       [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  0,  0,      1,  2,  3,      4,  5,  7,      11,    true_max_tiers[STATUES], 99],

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -29,7 +29,7 @@ from consts import (
     obolsDict, ignorable_obols_list,
     islands_dict, killroy_dict,
     # W3
-    refineryDict, buildingsDict, saltLickList, atomsList, colliderStorageLimitList, shrinesList, prayersDict,
+    refineryDict, buildingsDict, saltLickList, atomsList, colliderStorageLimitList, buildings_shrines, prayersDict,
     equinoxBonusesDict, max_implemented_dreams, dreamsThatUnlockNewBonuses,
     printerAllIndexesBeingPrinted,
     apocableMapIndexDict, apocAmountsList, apocNamesList, dn_miniboss_names, dn_miniboss_skull_requirement_list, dnSkullValueList, getSkullNames,
@@ -248,6 +248,8 @@ def _parse_general_gemshop(account):
         except Exception as e:
             logger.warning(f"Gemshop Parse error with purchaseIndex {purchaseIndex}: {e}. Defaulting to 0")
             account.gemshop[purchaseName] = 0
+
+    account.minigame_plays_daily = 5 + (4 * account.gemshop['Daily Minigame Plays'])
 
 def _parse_general_gemshop_optlacc(account):
     for purchase_name, optlacc_index in gem_shop_optlacc_dict.items():
@@ -1012,9 +1014,10 @@ def _parse_w2_p2w(account):
         
 def _parse_w2_postOffice(account):
     account.postOffice = {
-        'Completing Orders': safer_convert(account.raw_data.get("CYDeliveryBoxComplete"), 0),
-        'Streak Bonuses': safer_convert(account.raw_data.get("CYDeliveryBoxStreak"), 0),
-        'Miscellaneous': safer_convert(account.raw_data.get("CYDeliveryBoxMisc"), 0),
+        'Completing Orders': safer_convert(account.raw_data.get("CYDeliveryBoxComplete", 0), 0),
+        'Streak Bonuses': safer_convert(account.raw_data.get("CYDeliveryBoxStreak", 0), 0),
+        'Miscellaneous': safer_convert(account.raw_data.get("CYDeliveryBoxMisc", 0), 0),
+        'Upgrade Vault': safer_convert(account.raw_optlacc_dict.get(347, 0), 0)
     }
 
 def _parse_w2_arcade(account):
@@ -1416,7 +1419,7 @@ def _parse_w3_equinox_bonuses(account):
 def _parse_w3_shrines(account):
     account.shrines = {}
     raw_shrines_list = safe_loads(account.raw_data.get("Shrine", []))
-    for shrineIndex, shrineName in enumerate(shrinesList):
+    for shrineIndex, shrineName in enumerate(buildings_shrines):
         try:
             account.shrines[shrineName] = {
                 "MapIndex": int(raw_shrines_list[shrineIndex][0]),

--- a/mysite/taskSuggester.py
+++ b/mysite/taskSuggester.py
@@ -172,6 +172,7 @@ def main(inputData, source_string, runType="web"):
 
     #Remove the later-rated sections if Overwhelmed mode is on
     if session_data.overwhelmed:
+        placements_count = 0
         sections_to_keep = []
         for section in sections_pinchy:
             if section.name == 'Pinchy all':
@@ -179,9 +180,12 @@ def main(inputData, source_string, runType="web"):
                     # Skip the Alerts group, if it exists
                     if group.pre_string == 'Alerts':
                         continue
+                    placements_count += 1
                     for advice in group.advices['default']:
                         sections_to_keep.append(advice.label)
-                    break
+                    if placements_count >= session_data.account.maxSubgroupsPerGroup + 1:
+                        #Currently this should break after 2
+                        break
 
         #Remove all the later-rated Sections
         sections_general = [section for section in sections_general if section.name in sections_to_keep]

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,13 +7,13 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-04-07: TBD, maybe Summoning Upgrade stats/recommendations, Cog Stats, or other requests
+        Beta testing: 2025-04-15: TBD
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}
     </p>
     <p>
-        Latest Update 2025-04-07: Summoning Doubler expansion, GStack info tiers, few other litle improvements
+        Latest Update 2025-04-14: Library now grouped by Priority. More Statues in Gstack difficulty groups. Overwhelmed Mode setting renamed.
     </p>
     <form action="/" method="POST">
         <div id="switchbox-wrapper">

--- a/mysite/w2/bonus_ballot.py
+++ b/mysite/w2/bonus_ballot.py
@@ -47,6 +47,7 @@ def getBallotMultiAdviceGroup():
     endless = session_data.account.summoning['Endless Bonuses']['% Ballot Bonus']
     voter_integrity = session_data.account.caverns['Majiks']['Voter Integrity']
     gvb = session_data.account.event_points_shop['Bonuses']['Gilded Vote Button']
+    rvb = session_data.account.event_points_shop['Bonuses']['Royal Vote Button']
     multis_advice = {
         f"Total Multi: {session_data.account.ballot['BonusMulti']:.2f}x": [
             Advice(
@@ -65,6 +66,12 @@ def getBallotMultiAdviceGroup():
                 label=f"{{{{Event Shop|#event-shop}}}}: Gilded Vote Button: {gvb['Description']}",
                 picture_class=gvb['Image'],
                 progression=int(gvb['Owned']),
+                goal=1
+            ),
+            Advice(
+                label=f"{{{{Event Shop|#event-shop}}}}: Royal Vote Button: {rvb['Description']}",
+                picture_class=rvb['Image'],
+                progression=int(rvb['Owned']),
                 goal=1
             ),
             Advice(

--- a/mysite/w3/worship.py
+++ b/mysite/w3/worship.py
@@ -7,6 +7,14 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+def get_antifun_spirit_next_level_cost(current_prayer_level: int) -> int:
+    max_cost = round(9 + (optional_prayers['Antifun Spirit'] * .9))  #Max level
+    if current_prayer_level >= optional_prayers['Antifun Spirit']:
+        return max_cost
+    else:
+        result = round(9 + (current_prayer_level+1 * .9))
+        return result
+
 def setPrayersProgressionTierAdviceGroup():
     prayers_AdviceDict = {
         "Recommended": {},
@@ -46,16 +54,24 @@ def setPrayersProgressionTierAdviceGroup():
             tier_WorshipPrayers = tier[0]
 
     # Check Optional Prayers
+    next_antifun_cost = get_antifun_spirit_next_level_cost(worshipPrayersDict['Antifun Spirit']['Level'])
     for optionalPrayer in optional_prayers:
         if worshipPrayersDict[optionalPrayer]['Level'] < optional_prayers[optionalPrayer]:
-            prayers_AdviceDict["Optional"].append(
-                Advice(
-                    label=optionalPrayer,
-                    picture_class=optionalPrayer,
-                    progression=str(worshipPrayersDict[optionalPrayer]['Level']),
-                    goal=str(optional_prayers[optionalPrayer]),
-                    resource=worshipPrayersDict[optionalPrayer]['Material']
-                ))
+            if (
+                optionalPrayer == 'Antifun Spirit'
+                and session_data.account.minigame_plays_daily < next_antifun_cost
+            ):
+                #logger.debug(f"Skipping Antifun Spirit because next level costs {next_antifun_cost} while player has {session_data.account.minigame_plays_daily} daily minigame plays")
+                continue
+            else:
+                prayers_AdviceDict["Optional"].append(
+                    Advice(
+                        label=optionalPrayer,
+                        picture_class=optionalPrayer,
+                        progression=str(worshipPrayersDict[optionalPrayer]['Level']),
+                        goal=str(optional_prayers[optionalPrayer]),
+                        resource=worshipPrayersDict[optionalPrayer]['Material']
+                    ))
 
     # Check Ignorable Prayers
     for ignorablePrayer in ignorable_prayers:


### PR DESCRIPTION
* W3 Library > Group by Priority (#240)

* Add W4 statues to Gstacks T13

* Antifun Spirit QOL

### W3 > Prayers
* Remove Antifun Spirit advice from the Situational Prayers group if leveling the prayer would cost more Minigame Plays than the player can afford

* Add Upgrade Vault source to Post Office boxes

* Add Wiz Tower levels from Gambit

* Add Royal Vote Button to sources

* Add W5 + Cavern Statues to Gstacks

* Added Villager Statues to Tier 13
* Added W5 Statues plus Dragon Warrior Statues to Tier 14

* Rename Overwhelmed + Stamp reductions

### Overwhelmed Mode
* Changed the display on the slider from `Overwhelmed Mode` to `Display lowest rated sections only` ### W1 Stamps
* Changed Lab Tube Stamp from Required to Optional in Tier 13
* Reduced placement requirements by 1 from Late W2 through Solid W7 prep. Previously 3-18, now 2-17