### PR TITLE
Beta 2025 04 19 (#249)

### DIFF
--- a/changelog/CHANGELOG
+++ b/changelog/CHANGELOG
@@ -1,3 +1,4 @@
+2025-04-21: Setting Switch to group Library by Character. More GStacks. Measurement Villager max value goals.
 2025-04-14: Library now grouped by Priority. More Statues in Gstack difficulty groups. Overwhelmed Mode setting renamed.
 2025-04-07: Summoning Doubler expansion, GStack info tiers, few other litle improvements
 2025-04-03: v2.35 changes and additions to Cards, Inventory, Storage, Greenstacks, Event Shop, Arcade, and Slab

--- a/mysite/consts.py
+++ b/mysite/consts.py
@@ -123,206 +123,262 @@ gemShop_progressionTiers = [
      "This final tier is for the truly depraved. Many of these bonuses are very weak or outright useless."]
 ]
 greenstack_item_difficulty_groups = {
-        0: {  # The timegated tier
-            "Vendor Shops": [
-                "CraftMat3",  # W1 Cue Tape
-                "FoodPotRe2", "FoodHealth4", "Quest19",  # W2
-                "FoodHealth9", "FoodHealth11", "FoodPotGr3",  #W3
-                "FoodHealth12", "FoodHealth13", "FoodPotOr4", "FoodPotGr4", "FoodPotRe4", "FoodPotYe4",  #W4
-                "FoodHealth14", "FoodHealth15", "OilBarrel6",  #W5
-                "FoodHealth16", "FoodHealth17", "OilBarrel7",  #W6
-            ],
-            "Other Skilling Resources": [
-                "Refinery1", "Refinery2", "Refinery3", "Refinery4", "Refinery5", "Refinery6"],
-        },
-        1: {
-            "Printable Skilling Resources": [
-                "OakTree", "BirchTree", "JungleTree", "ForestTree", "ToiletTree", "PalmTree", "StumpTree", "SaharanFoal",
-                "Copper", "Iron", "Gold", "Plat", "Dementia", "Void", "Lustre",
-                "Fish1", "Fish2", "Fish3",
-                "Bug1", "Bug2"],
-            },
-        2: {
-            "Printable Skilling Resources": [
-                "Tree7", "AlienTree", "Tree8", "Tree9", "Tree11",
-                "Starfire", "Marble",
-                "Fish4", "Fish5", "Fish6", "Fish7",
-                "Bug3", "Bug4", "Bug5", "Bug6", "Bug7", "Bug8"],
-            "Other Skilling Resources": [
-                "CraftMat1",],
-            "Vendor Shops": [
-                "FoodHealth14", "FoodHealth15",]
-            },
-        3: {
-            "Base Monster Materials": [
-                "Grasslands1", "Grasslands2", "Grasslands4", "Grasslands3", "Jungle1", "Jungle2", "Jungle3", "Forest1", "Forest2", "Forest3",],
-            "Printable Skilling Resources": [
-                "Tree10",
-                "Dreadlo",
-                "Fish8", "Fish9", "Fish10",
-                "Bug9", "Bug11"],
-            "Other Skilling Resources": [
-                "CraftMat5",],
-            "Vendor Shops": [
-                "FoodHealth12", "FoodHealth13",],
-            },
-        4: {
-            "Base Monster Materials": [
-                "Sewers1", "Sewers2", "TreeInterior1", "TreeInterior2",],
-            "Printable Skilling Resources": [
-                "Tree12",
-                "Godshard",
-                "Fish11", "Fish12", "Fish13",
-                "Bug12", "Bug13",],
-            "Other Skilling Resources": [
-                "CraftMat6", "Soul1",],
-            "Vendor Shops": [
-                "FoodHealth16", "FoodHealth17",
-                "FoodPotOr4", "FoodPotGr4", "FoodPotRe4", "FoodPotYe4",]
-            },
-        5: {
-                "Base Monster Materials": [
-                    "DesertA1", "DesertA2", "DesertA3", "DesertB1", "DesertB2", "DesertB3", "DesertB4", "DesertC1", "DesertC2", "DesertC3", "DesertC4",
-                    "SnowA1", "SnowA2", "SnowA3",],
-                "Printable Skilling Resources": [
-                    "Tree13",],
-                "Other Skilling Resources": [
-                    "CraftMat7", "CraftMat9",
-                    "Critter1", "Critter2",
-                    "Soul2",],
-            },
-        6: {
-            "Base Monster Materials": [
-                "SnowB1", "SnowB2", "SnowB5", "SnowB3", "SnowB4", "SnowC1", "SnowC2", "SnowC3", "SnowC4",
-                "GalaxyA1", "GalaxyA2", "GalaxyA3", "GalaxyA4", "GalaxyB1", "GalaxyB2", ],
-            "Other Skilling Resources": [
-                "CraftMat8", "CraftMat10",
-                "Critter3", "Critter4",
-                "Soul3",]
-            },
-        7: {
-            "Base Monster Materials": [
-                "SnowA4", "SnowC5",
-                "GalaxyB3", "GalaxyB4", "GalaxyB5", "GalaxyC1", "GalaxyC2", "GalaxyC3", "GalaxyC4"],
-            "Crystal Enemy Drops": [
-                "FoodPotMana1", "FoodPotMana2", "FoodPotGr1", "FoodPotOr2", "FoodHealth1", "FoodHealth3", "FoodHealth2", "Leaf1"],
-            "Other Skilling Resources": [
-                "CraftMat11",
-                "Critter5",
-                "Soul4",],
-            },
-        8: {
-            "Base Monster Materials": [
-                "LavaA1", "LavaA2", "LavaA3", "LavaA4", "LavaA5", "LavaB1", "LavaB2", "LavaB3", "LavaB4", "LavaB5",
-                "SpiA1", "SpiA2",
-            ],
-            "Crystal Enemy Drops": [
-                "FoodHealth6", "FoodHealth7", "FoodPotGr2", "FoodPotRe3",],
-            "Other Skilling Resources": [
-                "CraftMat12",
-                "Critter6", "Critter7",
-                "Soul5",],
-            },
-        9: {
-            "Base Monster Materials": [
-                "LavaB6", "LavaC1", "LavaC2",  #Can beat Kruk and move to W6 without fighting these
-                "SpiA3", "SpiA4", "SpiA5", "SpiB1", "SpiB2", "SpiB3", "SpiB4", "SpiC1", "SpiC2",],
-            "Crystal Enemy Drops": [
-                "FoodHealth10", "FoodPotOr3", "FoodPotYe2", ],
-            "Other Skilling Resources": [
-                "CraftMat13", "CraftMat14",
-                "Critter8", "Critter9",
-                "Soul6",],
-            },
-        10: {
-            "Base Monster Materials": [
-                 "SpiD1", "SpiD2", "SpiD3",],
-            "Crystal Enemy Drops": [
-                "Leaf2",
-                "Leaf3",
-                "FoodPotMana4", "Leaf4",
-                "FoodPotYe5", "Leaf5",
-                "Leaf6",],
-            "Printable Skilling Resources": [],
-            "Other Skilling Resources": [
-                "Soul7",
-                "CopperBar", "IronBar", "GoldBar", "PlatBar", "DementiaBar", "VoidBar",
-                "FoodMining1", "FoodFish1", "FoodCatch1", "Bullet", "BulletB"
-            ],
-            "Vendor Shops": [
-                "OilBarrel6", "OilBarrel7",],
-            },
-        11: {
-            "Missable Quest Items": [
-                "Quest3", "Quest4", "Quest7", "Quest12"
-                "Quest14", "Quest22", "Quest23", "Quest24",
-                "Quest32",
-            ],
-            "Crystal Enemy Drops": [
-                "FoodPotOr1",
-            ],
-            "Other Skilling Resources": [
-                "LustreBar", "StarfireBar", "DreadloBar", "MarbleBar", "GodshardBar",
-                "Critter10", "Critter11",
-            ],
-            "Rare Drops": ['Quest78'],
-            },
-        12: {
-            "Missable Quest Items": ["GoldricP1", "GoldricP2", "GoldricP3", "Quest21"],
-            "Base Monster Materials": ["Sewers3"],
-            "Crystal Enemy Drops": [
-                "EquipmentStatues7", "EquipmentStatues3", "EquipmentStatues2", "EquipmentStatues4", "EquipmentStatues14",
-                ],
-            "Other Skilling Resources": [
-
-                "Peanut", "Quest68", "Bullet3", "FoodChoppin1",],  #I really hate that the Slush Bucket is listed as Quest68
-            "Rare Drops": ["FoodPotRe1"],
-            },
-        13: {
-            "Base Monster Materials": [
-                "Quest15", "Hgg"],
-            "Crystal Enemy Drops": [
-                "EquipmentStatues1", "EquipmentStatues5",  #Power and Health statues are still more common than W2 statues
-                "EquipmentStatues10", "EquipmentStatues12", "EquipmentStatues13", "EquipmentStatues8", "EquipmentStatues11",  #W2 statues
-                "EquipmentStatues18",  #W3 EhExPee statue
-                "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
-                "rtt0",
-                "StoneA1", "StoneW1", "StoneZ1", "StoneT1",
-                "StoneZ2", "StoneT2",
-                "PureWater",
-                "FoodG9",],
-            "Other Skilling Resources": [
-                "EquipmentSmithingTabs2",
-                'EquipmentSmithingTabs3',
-                "PeanutG",
-            ],
-            "Rare Drops": [
-                "FoodPotMana3", "ButterBar", "EquipmentStatues9", "OilBarrel2", "FoodPotRe2", "FoodPotGr3", "FoodHealth9",
-                'EquipmentStatues29',  # Villager Statues from Caverns
-            ],
-        },
-        14: {
-            "Crystal Enemy Drops": [
-                "StoneW2", 'ResetFrag', "SilverPen",
-                "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25",  # W5 Statues
-            ],  #"StoneA2",],
-            "Other Skilling Resources": [
-                "FoodTrapping1", "FoodWorship1",
-                "Critter1A", "Critter2A", "Critter3A", "Critter4A", "Critter5A", "Critter6A", "Critter7A", "Critter8A", "Critter9A", "Critter10A", "Critter11A",
-                "Ladle",
-            ],
-            "Rare Drops": [
-                "DesertC2b", "EfauntDrop1",
-                'EquipmentStatues30',  # Dragon Warrior Statues from Caverns
-            ]
-        },
+    0: {  # The timegated tier
+        "Vendor Shops": [
+            "CraftMat3",  # W1 Cue Tape
+            "FoodPotRe2", "FoodHealth4", "Quest19",  # W2
+            "FoodHealth9", "FoodHealth11", "FoodPotGr3",  #W3
+            "FoodHealth12", "FoodHealth13", "FoodPotOr4", "FoodPotGr4", "FoodPotRe4", "FoodPotYe4",  #W4
+            "FoodHealth14", "FoodHealth15", "OilBarrel6",  #W5
+            "FoodHealth16", "FoodHealth17", "OilBarrel7",  #W6
+        ],
+        "Other Skilling Resources": [
+            "Refinery1", "Refinery2", "Refinery3", "Refinery4", "Refinery5", "Refinery6"
+        ]
+    },
+    1: {
+        "Printable Skilling Resources": [
+            "OakTree", "BirchTree", "JungleTree", "ForestTree", "ToiletTree", "PalmTree", "StumpTree", "SaharanFoal",
+            "Copper", "Iron", "Gold", "Plat", "Dementia", "Void", "Lustre",
+            "Fish1", "Fish2", "Fish3",
+            "Bug1", "Bug2"
+        ]
+    },
+    2: {
+        "Printable Skilling Resources": [
+            "Tree7", "AlienTree", "Tree8", "Tree9", "Tree11",
+            "Starfire", "Marble",
+            "Fish4", "Fish5", "Fish6", "Fish7",
+            "Bug3", "Bug4", "Bug5", "Bug6", "Bug7", "Bug8"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat1"
+        ],
+        "Vendor Shops": [
+            "FoodHealth14", "FoodHealth15"
+        ]
+    },
+    3: {
+        "Base Monster Materials": [
+            "Grasslands1", "Grasslands2", "Grasslands4", "Grasslands3", "Jungle1", "Jungle2", "Jungle3", "Forest1", "Forest2", "Forest3"
+        ],
+        "Printable Skilling Resources": [
+            "Tree10",
+            "Dreadlo",
+            "Fish8", "Fish9", "Fish10",
+            "Bug9", "Bug11"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat5"
+        ],
+        "Vendor Shops": [
+            "FoodHealth12", "FoodHealth13"
+        ]
+    },
+    4: {
+        "Base Monster Materials": [
+            "Sewers1", "Sewers2", "TreeInterior1", "TreeInterior2"
+        ],
+        "Printable Skilling Resources": [
+            "Tree12",
+            "Godshard",
+            "Fish11", "Fish12", "Fish13",
+            'Bug10', "Bug12", "Bug13"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat6", "Soul1"
+        ],
+        "Vendor Shops": [
+            "FoodHealth16", "FoodHealth17",
+            "FoodPotOr4", "FoodPotGr4", "FoodPotRe4", "FoodPotYe4"
+        ]
+    },
+    5: {
+        "Base Monster Materials": [
+            "DesertA1", "DesertA2", "DesertA3", "DesertB1", "DesertB2", "DesertB3", "DesertB4", "DesertC1", "DesertC2", "DesertC3", "DesertC4",
+            "SnowA1", "SnowA2", "SnowA3"
+        ],
+        "Printable Skilling Resources": [
+            "Tree13"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat7", "CraftMat9",
+            "Critter1", "Critter2",
+            "Soul2"
+        ]
+    },
+    6: {
+        "Base Monster Materials": [
+            "SnowB1", "SnowB2", "SnowB5", "SnowB3", "SnowB4", "SnowC1", "SnowC2", "SnowC3", "SnowC4",
+            "GalaxyA1", "GalaxyA2", "GalaxyA3", "GalaxyA4", "GalaxyB1", "GalaxyB2"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat8", "CraftMat10",
+            "Critter3", "Critter4",
+            "Soul3"
+        ]
+    },
+    7: {
+        "Base Monster Materials": [
+            "SnowA4", "SnowC5",
+            "GalaxyB3", "GalaxyB4", "GalaxyB5", "GalaxyC1", "GalaxyC2", "GalaxyC3", "GalaxyC4"
+        ],
+        "Crystal Enemy Drops": [
+            "FoodPotMana1", "FoodPotMana2", "FoodPotGr1", "FoodPotOr2", "FoodHealth1", "FoodHealth3", "FoodHealth2", "Leaf1"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat11",
+            "Critter5",
+            "Soul4"
+        ]
+    },
+    8: {
+        "Base Monster Materials": [
+            "LavaA1", "LavaA2", "LavaA3", "LavaA4", "LavaA5", "LavaB1", "LavaB2", "LavaB3", "LavaB4", "LavaB5",
+            "SpiA1", "SpiA2",
+        ],
+        "Crystal Enemy Drops": [
+            "FoodHealth6", "FoodHealth7", "FoodPotGr2", "FoodPotRe3"
+        ],
+        "Other Skilling Resources": [
+            "CraftMat12",
+            "Critter6", "Critter7",
+            "Soul5"
+        ]
+    },
+    9: {
+        "Base Monster Materials": [
+            "LavaB6", "LavaC1", "LavaC2",  #Can beat Kruk and move to W6 without fighting these
+            "SpiA3", "SpiA4", "SpiA5", "SpiB1", "SpiB2", "SpiB3", "SpiB4", "SpiC1", "SpiC2",],
+        "Crystal Enemy Drops": [
+            "FoodHealth10", "FoodPotOr3", "FoodPotYe2", ],
+        "Other Skilling Resources": [
+            "CraftMat13", "CraftMat14",
+            "Critter8", "Critter9",
+            "Soul6"
+        ]
+    },
+    10: {
+        "Base Monster Materials": [
+             "SpiD1", "SpiD2", "SpiD3"
+        ],
+        "Crystal Enemy Drops": [
+            "Leaf2",
+            "Leaf3",
+            "FoodPotMana4", "Leaf4",
+            "FoodPotYe5", "Leaf5",
+            "Leaf6"
+        ],
+        "Other Skilling Resources": [
+            "Soul7",
+            "CopperBar", "IronBar", "GoldBar", "PlatBar", "DementiaBar", "VoidBar",
+            "FoodMining1", "FoodFish1", "FoodCatch1", "Bullet", "BulletB"
+        ],
+        "Vendor Shops": [
+            "OilBarrel6", "OilBarrel7"
+        ]
+    },
+    11: {
+        "Missable Quest Items": [
+            "Quest3", "Quest4", "Quest7", "Quest12",
+            "Quest14", "Quest22", "Quest23", "Quest24",
+            "Quest32"
+        ],
+        "Crystal Enemy Drops": [
+            "FoodPotOr1"
+        ],
+        "Other Skilling Resources": [
+            "LustreBar", "StarfireBar", "DreadloBar", "MarbleBar", "GodshardBar",
+            "Critter10", "Critter11"
+        ],
+        "Rare Drops": [
+            'Quest78'
+        ]
+    },
+    12: {
+        "Missable Quest Items": [
+            "GoldricP1", "GoldricP2", "GoldricP3", "Quest21"
+        ],
+        "Base Monster Materials": [
+            "Sewers3"
+        ],
+        "Crystal Enemy Drops": [
+            "EquipmentStatues7", "EquipmentStatues3", "EquipmentStatues2", "EquipmentStatues4", "EquipmentStatues14",
+        ],
+        "Other Skilling Resources": [
+            "Peanut", "Quest68", "Bullet3", "FoodChoppin1"  #I really hate that the Slush Bucket is listed as Quest68
+        ],
+        "Rare Drops": [
+            "FoodPotRe1"
+        ]
+    },
+    13: {
+        "Base Monster Materials": [
+            "Quest15", "Hgg"
+        ],
+        "Crystal Enemy Drops": [
+            "EquipmentStatues1", "EquipmentStatues5",  #Power and Health statues are still more common than W2 statues
+            "EquipmentStatues10", "EquipmentStatues12", "EquipmentStatues13", "EquipmentStatues8", "EquipmentStatues11",  #W2 statues
+            "EquipmentStatues18",  #W3 EhExPee statue
+            "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
+            "rtt0",
+            "StoneA1", "StoneW1", "StoneZ1", "StoneT1",
+            "StoneZ2", "StoneT2",
+            "PureWater",
+            "FoodG9"
+        ],
+        "Other Skilling Resources": [
+            "EquipmentSmithingTabs2",
+            'EquipmentSmithingTabs3',
+            "PeanutG"
+        ],
+        "Rare Drops": [
+            "FoodPotMana3", "ButterBar", "EquipmentStatues9", "OilBarrel2", "FoodPotRe2", "FoodPotGr3", "FoodHealth9",
+            'EquipmentStatues29',  # Villager Statues from Caverns
+        ]
+    },
+    14: {
+        "Crystal Enemy Drops": [
+            "StoneW2", 'ResetFrag', "SilverPen",
+            "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25",  # W5 Statues
+        ],
+        "Other Skilling Resources": [
+            "FoodTrapping1", "FoodWorship1",
+            "Ladle"
+        ],
+        "Rare Drops": [
+            'Sewers1b',  #W1 Golden Plop
+            'DesertC2b', 'DesertA3b',  #W2 Ghost and Nuget Cake
+            'SnowC4a', 'SnowB2a',  #W3 Black Lense and Ice Age 3
+            'EfauntDrop1',
+            'EquipmentStatues15',  #Bullseye
+            'EquipmentStatues16', 'EquipmentStatues17', 'EquipmentStatues19',  # W3 Statues
+            'EquipmentStatues30'  # Dragon Warrior Statues from Caverns
+        ]
+    },
+    15: {
+        'Crystal Enemy Drops': [
+            'StoneA2'
+        ],
+        "Other Skilling Resources": [
+            "Critter1A", "Critter2A", "Critter3A", "Critter4A", "Critter5A",
+            "Critter6A", "Critter7A", "Critter8A", "Critter9A", "Critter10A",
+            "Critter11A"
+        ],
+        'Rare Drops': [
+            'DesertA1b',  #W2 Glass Shard
+            'SnowA2a',  #W3 Yellow Snowflake
+            'GalaxyC1b', 'GalaxyA2b',  #W4 Pearler Shell + Lost Batteries
+            'LavaA1b', 'LavaA5b', 'LavaB3b', 'Key5'  # W5 Rare Drops
+        ]
     }
+}
 greenstack_progressionTiers = {
     1: {'Dream Number': 1, 'Required Stacks': 20},
     2: {'Dream Number': 12, 'Required Stacks': 75},
     3: {'Dream Number': 29, 'Required Stacks': 200},
-    4: {'Required Stacks': 250},  #Arbitrary based on LBs at the moment
-    5: {'Required Stacks': 299}
+    4: {'Required Stacks': 250},
+    5: {'Required Stacks': 319}
 }
 achievements_progressionTiers = {
     0: {},
@@ -1927,6 +1983,13 @@ switches = [
         "static": "true",
     },
     {
+        "label": "Group Library by Character",
+        "name": "library_group_characters",
+        "true": "",
+        "false": "",
+        "static": "true",
+    },
+    {
         "label": "Hide Completed",
         "name": "hide_completed",
         "true": "",
@@ -2040,12 +2103,11 @@ expectedStackables = {
         "EquipmentStatues1", "EquipmentStatues5",  # Plausible but time consuming
         "EquipmentStatues10", "EquipmentStatues12", "EquipmentStatues13", "EquipmentStatues8", "EquipmentStatues11",  # W2 statues are all slower than Power/Health
         "rtt0", "StoneZ1", "StoneT1", "StoneW1", "StoneA1",  #W1 Slow drops = Town TP + Stones
-        "StoneT2", "StoneZ2",  "StoneW2",  #"StoneA2", # W2 upgrade stones and Mystery2
+        "StoneT2", "StoneZ2",  "StoneW2", "StoneA2", # W2 upgrade stones and Mystery2
         "PureWater", "EquipmentStatues18",  #W3 Slow drops = Distilled Water + EhExPee Statue
         "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
         "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25", "FoodG9",  #W5 Slow drops = Golden W5 Sammy + Statues
-
-        "FoodG11", "FoodG12"
+        # "FoodG11", "FoodG12"  #W6 gold foods
     ],
     "Printable Skilling Resources": [
         "OakTree", "BirchTree", "JungleTree", "ForestTree", "ToiletTree", "PalmTree", "StumpTree", "SaharanFoal",  # Logs1
@@ -2091,21 +2153,23 @@ expectedStackables = {
         "FoodPotRe1",  #Small Life Potion from W1 Sewers and Tree mobs, not crystals
         "ButterBar",  #Catching Butterflies
         "EquipmentStatues9",  #Oceanman statue can be candied from W2 bugs
+        'EquipmentStatues15',  #Bullseye
+        'EquipmentStatues16', 'EquipmentStatues17', 'EquipmentStatues19',  # W3 Statues not from Crystals
         "FoodPotMana3",  #Decent Mana Potion from Bloques
         "FoodHealth9",  #Yeti Ham from Bop Box
         "OilBarrel2",  # Slime Barrel, 1 in 3334
-        "DesertC2b",  # Ghost, 1 in 2k
-        "Quest78",  # Equinox Mirror
+        'Sewers1b',  # W1 Golden Plop
+        "DesertC2b", 'DesertA3b', 'DesertA1b',  # W2 Ghost, Nuget Cake, Glass Shard
+        "Quest78", 'SnowC4a', 'SnowB2a', 'SnowA2a',  # W3 Equinox Mirror, Black Lense, Ice Age 3, Yellow Snowflake
+        'GalaxyC1b', 'GalaxyA2b',  #W4 Pearler Shell, Lost Batteries
+        'LavaA1b', 'LavaA5b', 'LavaB3b', 'Key5',  # W5 Rare Drops
         "EfauntDrop1",  # Basic Efaunt material
-        "Key2", "Key3",  # Efaunt and Chizoar keys
+        # "Key2", "Key3",  # Efaunt and Chizoar keys
         'EquipmentStatues29', 'EquipmentStatues30',  # Villager and Dragon Warrior statues from Caverns
     ],
     "Cheater": [
-        "Sewers1b", "TreeInterior1b", "BabaYagaETC", "JobApplication",  # W1 Rare Drops
-        "DesertA1b", "DesertA3b", "MidnightCookie",  # W2 Rare Drops
-        "SnowA2a", "SnowB2a", "SnowC4a",  # W3 Rare Drops
-        "GalaxyA2b", "GalaxyC1b",  # W4 Rare Drops
-        "LavaA1b", "LavaA5b", "LavaB3b",  # W5 Rare Drops
+        "TreeInterior1b", "BabaYagaETC", "JobApplication",  # W1 Rare Drops
+        "MidnightCookie",  # W2 Rare Drops
         "SpiA2b", "SpiB2b",  # W6 Rare Drops
         "EfauntDrop2", "Chiz0", "Chiz1", "TrollPart", "KrukPart", "KrukPart2",  # World Boss Materials
         "CraftMat2",  # Crimson String
@@ -2126,8 +2190,7 @@ expectedStackables = {
         "PetEgg", "Whetstone", "Quest72", "Quest73", "Quest76", "Quest77",  # Other Time Skips
         "Quest70", "Quest71", "Quest75", "Gfoodcoupon", "ItemsCoupon1", "ItemsCoupon2",  # Loot Bags
         "FoodHealth8", "Quest69", "Quest74",  # Unobtainables
-        "EquipmentStatues6", "EquipmentStatues15",  # Kachow and Bullseye
-        "EquipmentStatues16", "EquipmentStatues17", "EquipmentStatues19",  # W3 Statues
+        "EquipmentStatues6",  # Kachow
         "FoodG1", "FoodG2", "FoodG3", "FoodG4", "FoodG5", "FoodG6", "FoodG7", "FoodG8", "FoodG10",  # Gold Foods
         "ResetCompleted", "ResetCompletedS", "ClassSwap",
         "ClassSwapB", "ResetBox",
@@ -2138,6 +2201,28 @@ gstackable_codenames = [item for items in expectedStackables.values() for item i
 gstackable_codenames_expected = [
     item for items in list(expectedStackables.values())[:-1] for item in items
 ]
+gstacks_rated_items = []
+for dg in greenstack_item_difficulty_groups:
+    for category in greenstack_item_difficulty_groups[dg]:
+        for item_name in greenstack_item_difficulty_groups[dg][category]:
+            gstacks_rated_items.append(item_name)
+gstack_rated_not_expected = [item for item in gstacks_rated_items if item not in gstackable_codenames_expected]
+if len(gstack_rated_not_expected) > 0:
+    print(f"Rated but not Expected Greenstacks found: {gstack_rated_not_expected}")
+gstack_expected_not_rated = [item for item in gstackable_codenames_expected if item not in gstacks_rated_items]
+if len(gstack_expected_not_rated) > 0:
+    print(f"Expected but not Rated Greenstacks found: {gstack_expected_not_rated}")
+gstack_unique_expected = set()
+gstack_duplicate_expected = set()
+for item_name in gstackable_codenames_expected:
+    if item_name in gstack_unique_expected:
+        gstack_duplicate_expected.add(item_name)
+    else:
+        gstack_unique_expected.add(item_name)
+# if len(gstack_duplicate_expected) > 0:
+# These 3 are expected as they're sold in Vendor Shops category + Rare Drops from enemies {'FoodPotGr3', 'FoodPotRe2', 'FoodHealth9'}
+#     print(f"Reminder: Duplicate entries in GStack Expected list: {gstack_duplicate_expected}")
+greenstack_progressionTiers[5]['Required Stacks'] = len(gstack_unique_expected)
 quest_items_codenames = expectedStackables["Missable Quest Items"]
 key_cards = "Cards0"
 card_data = {
@@ -3330,7 +3415,7 @@ hardcap_enhancement_eclipse = 250  #Lava might add more in the future, but there
 librarySubgroupTiers = [
     'Account Wide Priorities', 'Skilling - High Priority', 'Skilling - Medium Priority', 'Skilling - Low Priority', 'Skilling - Lowest Priority',
     'Combat - High Priority', 'Combat - Medium Priority', 'Combat - Low Priority', 'ALL Unmaxed Talents', 'VIP'
-]  #Why is there a placeholder in [0] again?
+]
 skill_talentsDict = {
     # Optimal is an optional list for calculating library.getJeapordyGoal
     # [0] = the starting level
@@ -6511,7 +6596,7 @@ caverns_measurer_scalar_matchup = HolesInfo[52]
 caverns_measurer_scalars = HolesInfo[53]
 caverns_measurer_measurements = HolesInfo[54]
 caverns_measurer_HI55 = HolesInfo[55]
-max_measurements = sum(1 for measurement in caverns_measurer_measurements if measurement != 'i')  #i is a placeholder for not-implemented
+caverns_max_measurements = sum(1 for measurement in caverns_measurer_measurements if measurement != 'i')  #i is a placeholder for not-implemented
 caverns_measurer_measurement_names = [
     'Inches', 'Meters', 'Miles', 'Liters', 'Yards',
     'Pixels', 'Leagues', 'Nanometers', 'Sadness', 'Feet',
@@ -6533,6 +6618,14 @@ for entry_index, entry in enumerate(caverns_measurer_measurements):
             f"UnknownScalar{entry_index}",
             ''
         ]
+caverns_measurement_percent_goals = {
+    # "MeasurementBaseBonus" in source code
+    # =CosmosMulti * ScalingValue * (Level / (100 + Level))
+    # Numbers calculated by Xythium https://docs.google.com/spreadsheets/d/1krMdc1cGhKLBVv7XFEBU4BUbatyLHggEwp7XN5a6gAc/edit?usp=sharing
+    12: '10%', 25: '20%', 43: '30%', 67: '40%', 100: '50%', 150: '60%',
+    234: '70%', 300: '75%', 400: '80%', 567: '85%', 900: '90%', 1900: '95%',
+    2400: '96%', 3234: '97%', 4900: '98%', 9900: '99%'
+}
 caverns_librarian_studies = {}
 for entry_index, entry in enumerate(HolesInfo[69]):
     caverns_librarian_studies[entry_index] = [

--- a/mysite/general/gemShop.py
+++ b/mysite/general/gemShop.py
@@ -3,7 +3,7 @@ from utils.data_formatting import safe_loads, safer_get
 from utils.logging import get_logger
 from consts import (
     gemShop_progressionTiers, maxFarmingCrops, currentWorld, breedingTotalPets, cookingCloseEnough, break_you_best, max_cavern, max_majiks,
-    max_measurements, getMaxEngineerLevel, gem_shop_optlacc_dict, infinity_string
+    caverns_max_measurements, getMaxEngineerLevel, gem_shop_optlacc_dict, infinity_string
 )
 from flask import g as session_data
 
@@ -114,7 +114,7 @@ def try_exclude_ParallelVillagers(exclusionLists):
         for sublist in exclusionLists:
             sublist.append('Parallel Villagers The Conjuror')
         
-    if session_data.account.caverns['Villagers']['Minau']['Level'] >= max_measurements:
+    if session_data.account.caverns['Villagers']['Minau']['Level'] >= caverns_max_measurements:
         for sublist in exclusionLists:
             sublist.append('Parallel Villagers The Measurer')
 

--- a/mysite/general/greenstacks.py
+++ b/mysite/general/greenstacks.py
@@ -1,4 +1,4 @@
-from consts import missableGStacksDict, break_you_best, greenstack_progressionTiers, find_vendor_name
+from consts import missableGStacksDict, break_you_best, greenstack_progressionTiers, find_vendor_name, gstack_unique_expected
 from models.models import AdviceSection, AdviceGroup, Advice, gstackable_codenames_expected, Assets
 from utils.data_formatting import mark_advice_completed
 from utils.logging import get_logger
@@ -156,7 +156,7 @@ def getGStackAdviceSections():
         logger.warning('Unexpected GStack(s): %s', gstacks)
 
     #Get count of max expected gstacks
-    expectedStackablesCount = len(set(gstackable_codenames_expected))
+    expectedStackablesCount = len(gstack_unique_expected)
     expectedGStacksCount = len(all_owned_stuff.items_gstacked_expected)
     remainingToDoGStacksByTier = all_owned_stuff.items_gstackable_tiered
 

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -125,7 +125,6 @@ def _parse_wave_1(account, run_type):
     _parse_w6(account)
 
 def _parse_switches(account):
-
     # AutoLoot
     if g.autoloot:
         account.autoloot = True
@@ -136,6 +135,7 @@ def _parse_switches(account):
         account.autoloot = False
 
     account.maxSubgroupsPerGroup = 1 if g.overwhelmed else 3
+    account.library_group_characters = g.library_group_characters
 
 def _parse_companions(account):
     # Companions v2
@@ -2407,20 +2407,39 @@ def _parse_caverns_the_bell(account, raw_caverns_list):
     cavern_name = 'The Bell'
 
     # Charge
+    account.caverns['Caverns'][cavern_name]['Charges'] = {}
     try:
-        account.caverns['Caverns'][cavern_name]['Charges'] = {
-            'Ring': [raw_caverns_list[18][0], raw_caverns_list[18][1], getBellExpRequired(0, raw_caverns_list[18][1])],
-            'Ping': [raw_caverns_list[18][2], raw_caverns_list[18][3], getBellExpRequired(1, raw_caverns_list[18][3])],
-            'Clean': [raw_caverns_list[18][4], raw_caverns_list[18][5], getBellExpRequired(2, raw_caverns_list[18][5])],
-            'Renew': [raw_caverns_list[18][6], raw_caverns_list[18][7], getBellExpRequired(3, raw_caverns_list[18][7])],
-        }
+        account.caverns['Caverns'][cavern_name]['Charges']['Ring'] = [
+            safer_convert(raw_caverns_list[18][0], 0),
+            safer_convert(raw_caverns_list[18][1], 0),
+            getBellExpRequired(0, raw_caverns_list[18][1])
+        ]
     except:
-        account.caverns['Caverns'][cavern_name]['Charges'] = {
-            'Ring': [0, 0, getBellExpRequired(0, 0)],
-            'Ping': [0, 0, getBellExpRequired(1, 0)],
-            'Clean': [0, 0, getBellExpRequired(2, 0)],
-            'Renew': [0, 0, getBellExpRequired(3, 0)],
-        }
+        account.caverns['Caverns'][cavern_name]['Charges']['Ring'] = [0, 0, getBellExpRequired(0, 0)],
+    try:
+        account.caverns['Caverns'][cavern_name]['Charges']['Ping'] = [
+            safer_convert(raw_caverns_list[18][2], 0),
+            safer_convert(raw_caverns_list[18][3], 0),
+            getBellExpRequired(1, raw_caverns_list[18][3])
+        ]
+    except:
+        account.caverns['Caverns'][cavern_name]['Charges']['Ping'] = [0, 0, getBellExpRequired(1, 0)]
+    try:
+        account.caverns['Caverns'][cavern_name]['Charges']['Clean'] = [
+            safer_convert(raw_caverns_list[18][4], 0),
+            safer_convert(raw_caverns_list[18][5], 0),
+            getBellExpRequired(2, raw_caverns_list[18][5])
+        ]
+    except:
+        account.caverns['Caverns'][cavern_name]['Charges']['Clean'] = [0, 0, getBellExpRequired(2, 0)]
+    try:
+        account.caverns['Caverns'][cavern_name]['Charges']['Renew'] = [
+            safer_convert(raw_caverns_list[18][6], 0),
+            safer_convert(raw_caverns_list[18][7], 0),
+            getBellExpRequired(3, raw_caverns_list[18][7])
+        ]
+    except:
+        account.caverns['Caverns'][cavern_name]['Charges']['Renew'] = [0, 0, getBellExpRequired(3, 0)]
 
     # Ring Bonuses
     account.caverns['Caverns'][cavern_name]['Ring Bonuses'] = {}

--- a/mysite/static/scripts/main.js
+++ b/mysite/static/scripts/main.js
@@ -27,6 +27,7 @@ const defaults = {
     riftslug: "off",
     sheepie: "off",
     order_tiers: "off",
+    library_group_characters: "off",
     hide_completed: "off",
     hide_informational: "off",
     hide_unrated: "off",

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,13 +7,13 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-04-15: TBD
+        Beta testing: 2025-04-22: Whatever the new patch is
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}
     </p>
     <p>
-        Latest Update 2025-04-14: Library now grouped by Priority. More Statues in Gstack difficulty groups. Overwhelmed Mode setting renamed.
+        Latest Update 2025-04-21: Setting Switch to group Library by Character. More GStacks. Measurement Villager max value goals.
     </p>
     <form action="/" method="POST">
         <div id="switchbox-wrapper">

--- a/mysite/utils/text_formatting.py
+++ b/mysite/utils/text_formatting.py
@@ -39,8 +39,8 @@ def is_username(data) -> bool:
         isinstance(data, str)
         and (
             len(data) < 16
-            or 'idleonefficiency.com' in data.lower()
-            or 'idleontoolbox.com' in data.lower()
+            or ('idleonefficiency.com' in data.lower() and len(data) < 200)
+            or ('idleontoolbox.com' in data.lower() and len(data) < 200)
             # or 'idleonleaderboards.com in data.lower()
         )
     )

--- a/mysite/w3/sampling.py
+++ b/mysite/w3/sampling.py
@@ -251,6 +251,11 @@ def getPrinterOutputAdviceGroup() -> AdviceGroup:
     supreme_wiring_value = (supreme_wiring_days * 2 * session_data.account.event_points_shop['Bonuses']['Supreme Wiring']['Owned'])
     supreme_wiring_multi = ValueToMulti(supreme_wiring_value)
 
+    biggole_mole_max_days = 100
+    biggole_mole_days = min(biggole_mole_max_days, safer_get(session_data.account.raw_optlacc_dict, 354, 0))
+    biggole_mole_value = biggole_mole_days * 1 * session_data.account.companions['Biggole Mole']
+    biggole_mole_multi = ValueToMulti(biggole_mole_value)
+
     anyDKMaxBooked = False
     bestKotRBook = 0
     anyDKMaxLeveled = False
@@ -298,7 +303,10 @@ def getPrinterOutputAdviceGroup() -> AdviceGroup:
     harriep_multi_aw = 3 if session_data.account.companions['King Doot'] else 1
     harriep_multi_cs = 3 if session_data.account.divinity['Divinities'][4]['Unlocked'] else 1
 
-    aw_multi = 1 * sm_multi * gr_multi * kotr_multi * charm_multi_active * ballot_multi_active * lab_multi_aw * harriep_multi_aw * supreme_wiring_multi
+    aw_multi = (
+        1 * sm_multi * gr_multi * kotr_multi * charm_multi_active * ballot_multi_active
+        * lab_multi_aw * harriep_multi_aw * supreme_wiring_multi * biggole_mole_multi
+    )
     aw_label = f"Account Wide: {aw_multi:.3f}x"
     cs_multi = lab_multi_cs * harriep_multi_cs
     cs_label = f"Character Specific: Up to {cs_multi}x"
@@ -351,16 +359,25 @@ def getPrinterOutputAdviceGroup() -> AdviceGroup:
         label=f"{{{{ Sailing|#sailing}}}}: Level {gr_level} Gold Relic:"
               f"<br>{gr_multi:.2f}x ({gr_days}/{gr_max_days} days)",
         picture_class="gold-relic",
-        progression=f"{gr_multi:.2f}",
-        unit="x"
+        progression=gr_days,
+        goal=gr_max_days
     ))
 
     po_AdviceDict[aw_label].append(Advice(
         label=f"{{{{ Event Shop|#event-shop}}}}: Supreme Wiring:"
               f"<br>{supreme_wiring_multi:.2f}x ({supreme_wiring_days}/{supreme_wiring_max_days} days)",
         picture_class='event-shop-4',
-        progression=f"{supreme_wiring_multi:.2f}",
-        unit="x"
+        progression=supreme_wiring_days,
+        goal=supreme_wiring_max_days
+    ))
+
+    po_AdviceDict[aw_label].append(Advice(
+        label=f"Companions: Biggole Mole: "
+              f"<br>{biggole_mole_multi:.2f}x ({biggole_mole_days}/{biggole_mole_max_days} days)"
+              f"{'<br>Note: May be inaccurate. Not all data contains Companions!' if not session_data.account.companions['Biggole Mole'] else ''}",
+        picture_class='biggole-mole',
+        progression=int(session_data.account.companions['Biggole Mole']),
+        goal=1
     ))
 
     po_AdviceDict[aw_label].append(Advice(


### PR DESCRIPTION
* Add new Switch to group W3 Library by Character

* Goal levels for decaying Measurements

### Caverns > Villagers
* Added a new line of text for goal levels based on % of max value breakpoints. Every 10% up to 70%, then 5% up to 95%, and finally 1% up to 99%

* Add Biggole Mole to sources of Printer Output

### W3 > Sampling
* Added Biggole Mole Companion to sources of Printer Output
* Updated the progress and goals for Gold Relic, Supreme Wiring, and Biggole Mole to be the number of days they can charge

* Even more Rares in Gstack tiers

### General > Greenstacks
* Added several more Statues and Rare Drops to the Greenstack Difficulty Groups
* Created Difficulty Group 15 and shuffled the Shiny Trapping Critters down there in an effort to keep around 20 items per tier

* Parse Caverns Bell Charges individually + safer_convert (Shoutout to the cheaters with e100 charge breaking my shit)