### PR TITLE
Drop Rate Advice (#252) (#269)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11
+
+WORKDIR /usr/src/app
+
+COPY mysite/requirements /tmp/requirements
+RUN pip install --no-cache-dir -r /tmp/requirements/dev.txt
+
+ENV PYTHONUNBUFFERED=1
+ENV FLASK_APP=flask_app:app
+ENV FLASK_ENV=development
+ENV FLASK_RUN_PORT=5000
+ENV FLASK_DEBUG=1
+
+CMD [ "python", "-m", "flask", "run", "--host=0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,19 @@ $env:FLASK_ENV = "development"
 $env:FLASK_RUN_PORT = 5000
 python -m flask run 
 ```
-or, if you're using PyCharm, run one of the two saved run configurations.
+#### Docker
+Build and run the container, which mounts the local code.
+Flask will auto-update files that are changed, so you shouldn't need to rebuild unless requirements change.
+``` bash
+docker build . -t idleon-auto-review-bot:latest
+docker run --rm -d --name iarb -p 5000:5000 -v mysite:/usr/src/app idleon-auto-review-bot:1.0.3
+```
+To tail the webserver logs use
+``` bash
+docker logs -f iarb
+```
+#### PyCharm
+Run one of the two saved run configurations.
 <hr/>
 
 ## Test

--- a/mysite/consts.py
+++ b/mysite/consts.py
@@ -673,6 +673,14 @@ smithing_progressionTiers = [
     [5, 200, 500, 291, "bottle-cap"],
     [6, 600, 700, 291, "condensed-zap"]
 ]
+owl_bonuses_of_orion = {
+    'Class XP': {'BaseValue': 5},
+    'Base Damage': {'BaseValue': 10},
+    'Total Damage': {'BaseValue': 2},
+    'Skill XP': {'BaseValue': 4},
+    'Drop Rate': {'BaseValue': 1},
+    'All Stat': {'BaseValue': 2}
+}
 owl_progressionTiers = {
     0: {},
     1: {
@@ -1245,18 +1253,15 @@ deathNote_progressionTiers = [
     [13, 10, 10, 10, 10, 10, 0,     0, 0,   0,  0,  0,  0, ""],
     [14, 10, 10, 10, 10, 10, 0,     0, 0,   0,  0,  0,  0, ""],
     [15, 10, 10, 10, 10, 10, 0,     0, 0,   0,  0,  0,  0, ""],
-    [16, 20, 10, 10, 10, 10, 0,     0, 0,   0,  0,  0,  0, ""],
-    [17, 20, 20, 10, 10, 10, 1,     0, 0,   0,  0,  0,  0, ""],
-    [18, 20, 20, 20, 10, 10, 2,     0, 0,   0,  0,  0,  0, ""],
-    [19, 20, 20, 20, 20, 10, 3,     0, 0,   15, 15, 15, 0, "Aim for Super CHOWs in 24hrs each (4m+ KPH)"],
-    [20, 20, 20, 20, 20, 20, 4,     0, 0,   26, 26, 26, 0, ""],
-    [21, 20, 20, 20, 20, 20, 5,     0, 0,   40, 40, 40, 0, ""],
-    [22, 20, 20, 20, 20, 20, 7,     0, 0,   53, 53, 53, 0, ""],
-    [23, 20, 20, 20, 20, 20, 10,    0, 0,   66, 66, 66, 0, ""],
-    [24, 20, 20, 20, 20, 20, 10,    0, 0,   73, 73, 73, 0, ""],
-    [25, 20, 20, 20, 20, 20, 20,    0, 0,   80, 80, 80, 0, ""],
-    [26, 20, 20, 20, 20, 20, 20,    0, 0,   84, 84, 83, 0, "As of v2.11, completing a Super CHOW on Boops is impossible."],
-    [27, 20, 20, 20, 20, 20, 20,    0, 0,   86, 86, 86, 86, "Info only"]
+    [16, 20, 10, 10, 10, 10, 0,     0, 0,   15, 15, 15, 0, ""],
+    [17, 20, 20, 10, 10, 10, 1,     0, 0,   26, 26, 26, 0, ""],
+    [18, 20, 20, 20, 10, 10, 2,     0, 0,   40, 40, 40, 0, ""],
+    [19, 20, 20, 20, 20, 10, 3,     0, 0,   53, 53, 53, 0, "Aim for Super CHOWs in 24hrs each (4m+ KPH)"],
+    [20, 20, 20, 20, 20, 20, 4,     0, 0,   66, 66, 66, 0, ""],
+    [21, 20, 20, 20, 20, 20, 10,    0, 0,   73, 73, 73, 0, ""],
+    [22, 20, 20, 20, 20, 20, 20,    0, 0,   80, 80, 80, 80, ""],
+    [23, 20, 20, 20, 20, 20, 20,    0, 0,   84, 84, 83, 82, ""],
+    [24, 20, 20, 20, 20, 20, 20,    0, 0,   86, 86, 86, 85, ""]
 ]
 buildingsPostBuffs_progressionTiers = [
     [0, "Unlock", [], "", ""],
@@ -1375,14 +1380,23 @@ atoms_progressionTiers = {
         'Atoms': {
             'Boron - Particle Upgrader': 30,
             'Hydrogen - Stamp Decreaser': 30,
-            #"Neon - Damage N' Cheapener": 30,
+            "Neon - Damage N' Cheapener": 30,
             'Fluoride - Void Plate Chef': 30,
         },
     },
     14: {
         'Atoms': {
-            'Aluminium - Stamp Supercharger': 30,
-            'Helium - Talent Power Stacker': 12,
+            'Aluminium - Stamp Supercharger': 50,
+            "Neon - Damage N' Cheapener": 50,
+            'Hydrogen - Stamp Decreaser': 45,
+            'Helium - Talent Power Stacker': 13,
+            'Lithium - Bubble Insta Expander': 50,
+            'Boron - Particle Upgrader': 50,
+            'Nitrogen - Construction Trimmer': 50,
+            'Carbon - Wizard Maximizer': 50,  #Questionable
+            'Oxygen - Library Booker': 50,  #Questionable
+            'Fluoride - Void Plate Chef': 50,  #Questionable
+            'Magnesium - Trap Compounder': 50  #Questionable
         },
     },
 }
@@ -2370,6 +2384,7 @@ for item_name in gstackable_codenames_expected:
 #     print(f"Reminder: Duplicate entries in GStack Expected list: {gstack_duplicate_expected}")
 greenstack_progressionTiers[5]['Required Stacks'] = len(gstack_unique_expected)
 quest_items_codenames = expectedStackables["Missable Quest Items"]
+max_card_stars = 5
 key_cards = "Cards0"
 cards_max_level = 6
 cardset_names = [
@@ -3384,21 +3399,36 @@ gem_shop_bundles_dict = {
     'bun_u': 'Ancient Echos Pack',
     'bun_v': 'Deathbringer Pack',
     'bun_w': 'Windwalker Pack',
-    # No bun_x yet as of v2.36
     'bun_y': 'Valenslime Day Pack',
     'bun_z': 'Fallen Spirits Pet Pack',
     'bon_a': 'Storage Ram Pack',
-    # No bon_b yet as of v2.36
+    # No bon_b, yet as of 2.36.0
     'bon_c': 'Blazing Star Anniversary Pack',
     'bon_d': 'Midnight Tide Anniversary Pack',
     'bon_e': 'Lush Emerald Anniversary Pack',
     'bon_f': 'Eternal Hunter Pack'
 }
-guildBonusesList = [
-    "Guild Gifts", "Stat Runes", "Rucksack", "Power of Pow", "REM Fighting", "Make or Break",
-    "Multi Tool", "Sleepy Skiller", "Coin Supercharger", "Bonus GP for small guilds", "Gold Charm", "Star Dazzle",
-    "C2 Card Spotter", "Bestone", "Skilley Skillet", "Craps", "Anotha One", "Wait A Minute"
-]
+
+guild_bonuses_dict = {
+    'Guild Gifts': {'Image': 'guild-gifts', 'Max Level': 100, 'Max Value': 350, 'funcType': 'decay', 'x1': 700, 'x2': 100},
+    'Stat Runes': {'Image': 'stat-runes', 'Max Level': 50, 'Max Value': 20, 'funcType': 'decay', 'x1': 40, 'x2': 50},
+    'Rucksack': {'Image': 'rucksack', 'Max Level': 50, 'Max Value': 35, 'funcType': 'decay', 'x1': 70, 'x2': 50},
+    'Power of Pow': {'Image': 'power-of-pow', 'Max Level': 50, 'Max Value': 5, 'funcType': 'decay', 'x1': 10, 'x2': 50},
+    'REM Fighting': {'Image': 'rem-fighting', 'Max Level': 50, 'Max Value': 5, 'funcType': 'decay', 'x1': 10, 'x2': 50},
+    'Make or Break': {'Image': 'make-or-break', 'Max Level': 50, 'Max Value': 15, 'funcType': 'decay', 'x1': 30, 'x2': 50},
+    'Multi Tool': {'Image': 'multi-tool', 'Max Level': 50, 'Max Value': 15, 'funcType': 'decay', 'x1': 30, 'x2': 50},
+    'Skilley Skiller': {'Image': 'skilley-skiller', 'Max Level': 50, 'Max Value': 5, 'funcType': 'decay', 'x1': 10, 'x2': 50},
+    'Coin Supercharger': {'Image': 'coin-supercharger', 'Max Level': 100, 'Max Value': 16.667, 'funcType': 'decay', 'x1': 20, 'x2': 20},
+    'Bonus GP for small guilds': {'Image': 'bonus-gp-for-small-guilds', 'Max Level': 50, 'Max Value': 0, 'funcType': 'special1', 'x1': 200, 'x2': 50}, # This value decreases to a min value of 0
+    'Gold Charm': {'Image': 'gold-charm', 'Max Level': 50, 'Max Value': 20, 'funcType': 'decay', 'x1': 40, 'x2': 50},
+    'Star Dazzle': {'Image': 'star-dazzle', 'Max Level': 50, 'Max Value': 60, 'funcType': 'decay', 'x1': 120, 'x2': 50},
+    'C2 Card Spotter': {'Image': 'c2-card-spotter', 'Max Level': 50, 'Max Value': 30, 'funcType': 'decay', 'x1': 60, 'x2': 50},
+    'Bestone': {'Image': 'bestone', 'Max Level': 50, 'Max Value': 8, 'funcType': 'decay', 'x1': 16, 'x2': 50},
+    'Sleepy Skillet': {'Image': 'sleepy-skillet', 'Max Level': 200, 'Max Value': 18.75, 'funcType': 'decay', 'x1': 30, 'x2': 120},
+    'Craps': {'Image': 'craps', 'Max Level': 50, 'Max Value': 14, 'funcType': 'decay', 'x1': 28, 'x2': 50},
+    'Anotha One': {'Image': 'anotha-one', 'Max Level': 50, 'Max Value': 13, 'funcType': 'decay', 'x1': 26, 'x2': 50},
+    'Wait A Minute': {'Image': 'wait-a-minute', 'Max Level': 0, 'Max Value': 0, 'funcType': 'add', 'x1': 1, 'x2': 0}
+}
 familyBonusClassTierLevelReductions = [9, 29, 69, 999]  #Character must be this high of a level to get bonuses
 familyBonusesDict = {
     #"Beginner": {'funcType': 'decay', 'x1': 0, 'x2': 0, 'Stat': '', 'PrePlus': False, 'PostDisplay': '', 'levelDiscount': familyBonusClassTierLevelReductions[0]},
@@ -4770,6 +4800,11 @@ combat_talentsDict = {
         }
     },
 }
+class_kill_talents_dict = {
+    'Archlord of the Pirates': {'BonusType': 'Drop Rate', 'funcType': 'decay', 'x1': 6, 'x2': 150},
+    'King of the Remembered': {'BonusType': 'Printer Output', 'funcType': 'decay', 'x1': 5, 'x2': 150},
+    'Wormhole Emperor': {'BonusType': 'Damage', 'funcType': 'decay', 'x1': 1.5, 'x2': 150}
+}
 unbookable_talents_list = [
     10, 11, 12,  #Tab 1 STR, AGI, WIS
     75, 79,      #Beginner tab1 Happy Dude and Sleepin' on the Job
@@ -4857,6 +4892,53 @@ companions = [
     # Exclusives
     'Cool Bird', 'Axolotl', 'Mallay', 'Reindeer'
 ]
+equipment_by_bonus_dict = {
+    'DropRate': {
+        # Weapons
+        'Mittens of the Gods': {'Type': 'Fisticuffs', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 120}, 'Misc2': {'Bonus': 'DropRate', 'Value': 40}, 'Image': 'mittens-of-the-gods'},
+        'Massive Godbreaker': {'Type': 'Spear', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 60}, 'Misc2': {'Bonus': 'DropRate', 'Value': 20}, 'Image': 'massive-godbreaker'},
+        'Doublestring Godshooter': {'Type': 'Bow', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 60}, 'Misc2': {'Bonus': 'DropRate', 'Value': 20}, 'Image': 'doublestring-godshooter'},
+        'Magnifique Godcaster': {'Type': 'Wand', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 60}, 'Misc2': {'Bonus': 'DropRate', 'Value': 20}, 'Image': 'magnifique-godcaster'},
+        # Tools
+        'Destroyer of the Mollo Gomme': {'Type': 'Pickaxe', 'Limited': False, 'Misc1': {'Bonus': 'MiningEff', 'Value': 35}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'destroyer-of-the-mollo-gomme'},
+        'Annihilator of the Yggdrasil': {'Type': 'Hatchet', 'Limited': False, 'Misc1': {'Bonus': 'ChoppingEff', 'Value': 12}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'annihilator-of-the-yggdrasil'},
+        'Angler of the Iliunne': {'Type': 'Rod', 'Limited': False, 'Misc1': {'Bonus': 'FishingEff', 'Value': 12}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'angler-of-the-iliunne'},
+        'Wrangler of the Qoxzul': {'Type': 'Net', 'Limited': False, 'Misc1': {'Bonus': 'CatchingEff', 'Value': 12}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'wrangler-of-the-qoxzul'},
+        'Containment of the Zrgyios': {'Type': 'Trap', 'Limited': False, 'Misc1': {'Bonus': 'AfkGain', 'Value': 4}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'containment-of-the-zrgyios'},
+        # Helmets
+        '3rd Anniversary Ice Cream Topper': {'Type': 'Helmet', 'Limited': True, 'Misc1': {'Bonus': 'MonsterXp', 'Value': 4}, 'Misc2': {'Bonus': 'DropRate', 'Value': 3}, 'Image': 'third-anniversary-ice-cream-topper'},
+        'Efaunt Helmet': {'Type': 'Helmet', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 5}, 'Image': 'efaunt-helmet'},
+        'Skulled Helmet of the Divine': {'Type': 'Helmet', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 30}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'skulled-helmet-of-the-divine'},
+        'Crown of the Gods': {'Type': 'Helmet', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 15}, 'Misc2': {'Bonus': 'MultikillPerTier', 'Value': 22}, 'Image': 'crown-of-the-gods'},
+        # Pendants
+        'Chaotic Amarok Pendant': {'Type': 'Pendant', 'Limited': False, 'Misc1': {'Bonus': 'Damage', 'Value': 20}, 'Misc2': {'Bonus': 'DropRate', 'Value': 5}, 'Image': 'chaotic-amarok-pendant'},
+        # Chests
+        'Robe of the Gods': {'Type': 'Chest', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 30}, 'Misc2': {'Bonus': 'MultikillPerTier', 'Value': 16}, 'Image': 'robe-of-the-gods'},
+        # Legs
+        'Tatters of the Gods': {'Type': 'Legs', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 25}, 'Misc2': {'Bonus': 'MultikillPerTier', 'Value': 14}, 'Image': 'tatters-of-the-gods'},
+        # Feet
+        'Devious Slippers of the Divine': {'Type': 'Feet', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 15}, 'Misc2': {'Bonus': 'Damage', 'Value': 8}, 'Image': 'devious-slippers-of-the-divine'},
+        'Drip of the Gods': {'Type': 'Feet', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 30}, 'Misc2': {'Bonus': 'MultikillPerTier', 'Value': 12}, 'Image': 'drip-of-the-gods'},
+        # Premium Hats
+        'Siege Captain Cap': {'Type': 'Premium Hat', 'Limited': True, 'Misc1': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'siege-captain-cap'},
+        'Goldberry': {'Type': 'Premium Hat', 'Limited': True, 'Misc1': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'goldberry'},
+        # Trophies
+        'Lucky Lad': {'Type': 'Trophy', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 7}, 'Image': 'lucky-lad'},
+        'Luckier Lad': {'Type': 'Trophy', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 50}, 'Misc2': {'Bonus': 'PercentLuck', 'Value': 5}, 'Image': 'luckier-lad'},
+        'One of the Divine': {'Type': 'Trophy', 'Limited': False, 'Misc1': {'Bonus': 'DropRate', 'Value': 42}, 'Misc2': {'Bonus': 'Damage', 'Value': 35}, 'Image': 'one-of-the-divine'},
+        # Capes
+        'Molten Cloak': {'Type': 'Cape', 'Limited': True, 'Misc1': {'Bonus': 'DropRate', 'Value': 30}, 'Image': 'molten-cloak'},
+        # Nametags
+        '3rd Anniversary IdleOn Nametag': {'Type': 'Nametag', 'Limited': True, 'Misc1': {'Bonus': 'AfkGain', 'Value': 3}, 'Misc2': {'Bonus': 'DropRate', 'Value': 3}, 'Image': 'third-anniversary-idleon-nametag'},
+        'Balling Nametag': {'Type': 'Nametag', 'Limited': True, 'Misc1': {'Bonus': 'DropRate', 'Value': 40}, 'Image': 'balling-nametag'},
+        'Aethermoon Nametag': {'Type': 'Nametag', 'Limited': True, 'Misc1': {'Bonus': 'AfkGain', 'Value': 80}, 'Misc2': {'Bonus': 'DropRate', 'Value': 10}, 'Image': 'aethermoon-nametag'},
+        # Attire
+        'Cobalt Robe':    {'Type': 'Attire', 'Limited': True, 'Misc1': {'Bonus': 'Damage', 'Value': 100}, 'Misc2': {'Bonus': 'DropRate', 'Value': 60}, 'Image': 'cobalt-robe'},
+        'Evergreen Robe': {'Type': 'Attire', 'Limited': True, 'Misc1': {'Bonus': 'ClassXp', 'Value': 100}, 'Misc2': {'Bonus': 'DropRate', 'Value': 75}, 'Image': 'evergreen-robe'},
+        # Keychains
+        'Relic Chain': {'Type': 'Keychain', 'Limited': False, 'Note': 'Relic can roll up to +16% total Drop Rate<br>All other Tier 2 keychains can only roll up to +8% Drop Rate', 'Misc1': {'Bonus': 'DropRate', 'Value': 16}, 'Image': 'relic-chain'}
+    }
+}
 
 def lavaFunc(funcType: str, level: int, x1: int | float, x2: int | float, roundResult=False):
     match funcType:
@@ -5461,30 +5543,30 @@ vialsDict = {
     74: {"Name": "Turtle Tisane", "Material": "Critter11", "x1": 4, "x2": 0, "funcType": "add"},
 }
 sigilsDict = {
-    "Big Muscle":       {"Index": 0,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [2, 100, 50000]},
-    "Pumped Kicks":     {"Index": 2,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [3, 150, 60000]},
-    "Odd Litearture":   {"Index": 4,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [5, 200, 70000]},
-    "Good Fortune":     {"Index": 6,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [8, 300, 90000]},
-    "Plunging Sword":   {"Index": 8,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [15, 700, 100000]},
-    "Wizardly Hat":     {"Index": 10, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [24, 1250, 130000]},
-    "Envelope Pile":    {"Index": 12, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [60, 2500, 160000]},
-    "Shiny Beacon":     {"Index": 14, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [120, 4000, 200000]},
-    "Metal Exterior":   {"Index": 16, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [250, 7000, 240000]},
-    "Two Starz":        {"Index": 18, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [500, 10000, 280000]},
-    "Pipe Gauge":       {"Index": 20, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [700, 12000, 320000]},
-    "Trove":            {"Index": 22, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [1300, 14000, 400000]},
-    "Pea Pod":          {"Index": 24, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [2100, 15000, 420000]},
-    "Tuft Of Hair":     {"Index": 26, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [3000, 25000, 450000]},
-    "Emoji Veggie":     {"Index": 28, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [4500, 33000, 480000]},
-    "VIP Parchment":    {"Index": 30, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [6300, 42000, 520000]},
-    "Dream Catcher":    {"Index": 32, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [7000, 50000, 560000]},
-    "Duster Studs":     {"Index": 34, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [8000, 60000, 600000]},
-    "Garlic Glove":     {"Index": 36, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [9000, 70000, 650000]},
-    "Lab Tesstube":     {"Index": 38, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [12000, 80000, 700000]},
-    "Peculiar Vial":    {"Index": 40, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [17000, 120000, 750000]},
-    "Loot Pile":        {"Index": 42, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [23000, 160000, 900000]},
-    "Div Spiral":       {"Index": 44, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [26000, 200000, 1200000]},
-    "Cool Coin":        {"Index": 46, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [30000, 250000, 2000000]},
+    "Big Muscle":       {"Index": 0,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [2, 100, 50000], 'Values': [10, 20, 40]},
+    "Pumped Kicks":     {"Index": 2,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [3, 150, 60000], 'Values': [10, 20, 40]},
+    "Odd Litearture":   {"Index": 4,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [5, 200, 70000], 'Values': [10, 20, 40]},
+    "Good Fortune":     {"Index": 6,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [8, 300, 90000], 'Values': [10, 20, 40]},
+    "Plunging Sword":   {"Index": 8,  "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [15, 700, 100000], 'Values': [75, 225, 1000]},
+    "Wizardly Hat":     {"Index": 10, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [24, 1250, 130000], 'Values': [10, 20, 30]},
+    "Envelope Pile":    {"Index": 12, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [60, 2500, 160000], 'Values': [10, 25, 40]},
+    "Shiny Beacon":     {"Index": 14, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [120, 4000, 200000], 'Values': [2, 2, 5]},
+    "Metal Exterior":   {"Index": 16, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [250, 7000, 240000], 'Values': [6, 12, 20]},
+    "Two Starz":        {"Index": 18, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [500, 10000, 280000], 'Values': [10, 25, 45]},
+    "Pipe Gauge":       {"Index": 20, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [700, 12000, 320000], 'Values': [10, 20, 30]},
+    "Trove":            {"Index": 22, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [1300, 14000, 400000], 'Values': [10, 20, 30]},
+    "Pea Pod":          {"Index": 24, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [2100, 15000, 420000], 'Values': [25, 50, 100]},
+    "Tuft Of Hair":     {"Index": 26, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [3000, 25000, 450000], 'Values': [3, 6, 10]},
+    "Emoji Veggie":     {"Index": 28, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [4500, 33000, 480000], 'Values': [10, 25, 40]},
+    "VIP Parchment":    {"Index": 30, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [6300, 42000, 520000], 'Values': [10, 25, 50]},
+    "Dream Catcher":    {"Index": 32, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [7000, 50000, 560000], 'Values': [1, 2, 4]},
+    "Duster Studs":     {"Index": 34, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [8000, 60000, 600000], 'Values': [3, 7, 15]},
+    "Garlic Glove":     {"Index": 36, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [9000, 70000, 650000], 'Values': [15, 25, 60]},
+    "Lab Tesstube":     {"Index": 38, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [12000, 80000, 700000], 'Values': [8, 20, 35]},
+    "Peculiar Vial":    {"Index": 40, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [17000, 120000, 750000], 'Values': [15, 25, 35]},
+    "Loot Pile":        {"Index": 42, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [23000, 160000, 900000], 'Values': [10, 20, 30]},
+    "Div Spiral":       {"Index": 44, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [26000, 200000, 1200000], 'Values': [10, 30, 50]},
+    "Cool Coin":        {"Index": 46, "PlayerHours": 0, "Level": 0, "PrechargeLevel": 0, "Requirements": [30000, 250000, 2000000], 'Values': [10, 30, 100]},
 }
 bubbleCauldronColorList = ['Orange', 'Green', 'Purple', 'Yellow']
 alchemy_liquids_list = ['Water Droplets', 'Liquid Nitrogen', 'Trench Seawater', 'Toxic Mercury']
@@ -5961,18 +6043,24 @@ fishingToolkitDict = {
         'Wiener Links', 'Zeus Gon Fishin', 'Needledrop', 'Scripticus Spoons', 'Its a Boy Celebration', 'Its a Girl Celebration', 'Its Alright Celebration'
     ],
 }
-obolsDict = {
+obols_dict = {
     #Drop Rate
-    "ObolBronzePop":    {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolBronzePop")},
-    "ObolSilverPop":    {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolSilverPop")},
-    "ObolHyper0":       {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolHyper0")},
-    "ObolSilverLuck":   {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolSilverLuck")},
-    "ObolGoldLuck":     {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolGoldLuck")},
-    "ObolKnight":       {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolKnight")},
-    "ObolHyperB0":       {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolHyper0")},
-    "ObolPlatinumLuck": {"Shape": "Hexagon", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolPlatinumLuck")},
-    "ObolLava":         {"Shape": "Hexagon", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolLava")},
-    "ObolPinkLuck":     {"Shape": "Sparkle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolPinkLuck")},
+    "ObolBronzePop":    {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolBronzePop"), 'Base': {'LUK': 1, 'DEF': 1, '%_DROP_CHANCE': 2}},
+    "ObolSilverPop":    {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolSilverPop"), 'Base': {'LUK': 3, 'DEF': 2, '%_DROP_CHANCE': 3}},
+    "ObolHyper0":       {"Shape": "Circle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolHyper0"), 'Base': {'WP': 1, '%_DROP_CHANCE': 4}},
+    "ObolSilverLuck":   {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolSilverLuck"), 'Base': {'LUK': 2, '%_DROP_CHANCE': 5}},
+    "ObolGoldLuck":     {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolGoldLuck"), 'Base': {'LUK': 3, '%_DROP_CHANCE': 7}},
+    "ObolKnight":       {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolKnight"), 'Base': {'WP': 2, 'STR': 3, 'AGI': 3, 'WIS': 3, 'LUK': 3, 'DEF': 5, '%_DROP_CHANCE': 8}},
+    "ObolHyperB0":      {"Shape": "Square", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolHyper0"), 'Base': {'WP': 5, '%_DROP_CHANCE': 10}},
+    "ObolPlatinumLuck": {"Shape": "Hexagon", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolPlatinumLuck"), 'Base': {'LUK': 5, '%_DROP_CHANCE': 10}},
+    "ObolLava":         {"Shape": "Hexagon", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolLava"), 'Base': {'LUK': 10, '%_DROP_CHANCE': 14}},
+    "ObolPinkLuck":     {"Shape": "Sparkle", "Bonus": "Drop Rate", "DisplayName": getItemDisplayName("ObolPinkLuck"), 'Base': {'LUK': 7, '%_DROP_CHANCE': 15}},
+}
+obols_max_bonuses_dict = {
+    'PlayerDropRatePractical': 134,  #12*4=48% circles, 6*8=48% squares,  2*11=22% hex, 1*16=16% sparkle
+    'PlayerDropRateTrue': 172,       #12*5=60% circles, 6*11=66% squares, 2*15=30% hex, 1*16=16% sparkle
+    'FamilyDropRatePractical': 188,  #12*4=48% circles, 4*8=32% squares,  4*11=44% hex, 4*16=64% sparkle
+    'FamilyDropRateTrue': 228        #12*5=60% circles, 4*11=44% squares, 4*15=60% hex, 4*16=64% sparkle
 }
 ignorable_obols_list = [
     'Blank', 'LockedInvSpace', 'ObolLocked1', 'ObolLocked2', 'ObolLocked3', 'ObolLocked4',
@@ -6154,61 +6242,61 @@ prayersList: list[str] = [
     "Balance of Pain (Squishy Soul)", "Balance of Proficiency (Squishy Soul)","Glitterbug (Squishy Soul)",
 ]
 prayersDict = {
-    0: {"Name": "Big Brain Time", "Material": "Forest Soul", "Display": "Big Brain Time (Forest Soul)",
+    0: {"Name": "Big Brain Time", "Material": "Forest Soul", "Display": "Big Brain Time (Forest Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Class EXP', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 225, 'curse_x2': 25, 'curse_stat': 'Max HP for all monsters', 'curse_pre': '+', 'curse_post': '%'},
-    1: {"Name": "Skilled Dimwit", "Material": "Forest Soul", "Display": "Skilled Dimwit (Forest Soul)",
+    1: {"Name": "Skilled Dimwit", "Material": "Forest Soul", "Display": "Skilled Dimwit (Forest Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Skill Efficiency', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 18, 'curse_x2': 2, 'curse_stat': 'Skill EXP Gain', 'curse_pre': '-', 'curse_post': '%'},
-    2: {"Name": "Unending Energy", "Material": "Forest Soul", "Display": "Unending Energy (Forest Soul)",
+    2: {"Name": "Unending Energy", "Material": "Forest Soul", "Display": "Unending Energy (Forest Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 22.5, 'bonus_x2': 2.5, 'bonus_stat': 'Class and Skill EXP', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 1, 'curse_x2': 0, 'curse_stat': 'Max AFK time is now 10 hours. Use with caution', 'curse_pre': '', 'curse_post': ''},
-    3: {"Name": "Shiny Snitch", "Material": "Forest Soul", "Display": "Shiny Snitch (Forest Soul)",
+    3: {"Name": "Shiny Snitch", "Material": "Forest Soul", "Display": "Shiny Snitch (Forest Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 18, 'bonus_x2': 2, 'bonus_stat': 'Shiny Critters per trap', 'bonus_pre': '+', 'bonus_post': '',
         "curse_funcType": 'bigBase', 'curse_x1': 13.5, 'curse_x2': 1.5, 'curse_stat': 'lower', 'curse_pre': 'Your Shiny chance is now ', 'curse_post': 'x'},
-    4: {"Name": "Zerg Rushogen", "Material": "Forest Soul", "Display": "Zerg Rushogen (Forest Soul)",
+    4: {"Name": "Zerg Rushogen", "Material": "Forest Soul", "Display": "Zerg Rushogen (Forest Soul)", "MaxLevel": 20,
         "bonus_funcType": 'bigBase', 'bonus_x1': 4.5, 'bonus_x2': 0.5, 'bonus_stat': 'All AFK Gain Rate', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 10.8, 'curse_x2': 1.2, 'curse_stat': 'Carry Capacity', 'curse_pre': '-', 'curse_post': '%'},
-    5: {"Name": "Tachion of the Titans", "Material": "Dune Soul", "Display": "Tachion of the Titans (Dune Soul)",
+    5: {"Name": "Tachion of the Titans", "Material": "Dune Soul", "Display": "Tachion of the Titans (Dune Soul)", "MaxLevel": 2,
         "bonus_funcType": 'bigBase', 'bonus_x1': 1, 'bonus_x2': 0, 'bonus_stat': 'Giant Monsters can now spawn on Monster Kill', 'bonus_pre': '', 'bonus_post': '',
         "curse_funcType": 'bigBase', 'curse_x1': 1, 'curse_x2': 0, 'curse_stat': 'Giant Monsters can now spawn...', 'curse_pre': '', 'curse_post': ''},
-    6: {"Name": "Balance of Precision", "Material": "Dune Soul", "Display": "Balance of Precision (Dune Soul)",
+    6: {"Name": "Balance of Precision", "Material": "Dune Soul", "Display": "Balance of Precision (Dune Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Total Accuracy', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 4.5, 'curse_x2': 0.5, 'curse_stat': 'Total Damage', 'curse_pre': '-', 'curse_post': '%'},
-    7: {"Name": "Midas Minded", "Material": "Dune Soul", "Display": "Midas Minded (Dune Soul)",
+    7: {"Name": "Midas Minded", "Material": "Dune Soul", "Display": "Midas Minded (Dune Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 18, 'bonus_x2': 2, 'bonus_stat': 'Drop Rate', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 225, 'curse_x2': 2.5, 'curse_stat': 'Max HP for all monsters', 'curse_pre': '+', 'curse_post': '%'},
-    8: {"Name": "Jawbreaker", "Material": "Dune Soul", "Display": "Jawbreaker (Dune Soul)",
+    8: {"Name": "Jawbreaker", "Material": "Dune Soul", "Display": "Jawbreaker (Dune Soul)", "MaxLevel": 50,
         "bonus_funcType": 'bigBase', 'bonus_x1': 36, 'bonus_x2': 4, 'bonus_stat': 'Coins from Monsters', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 180, 'curse_x2': 20, 'curse_stat': 'Max HP for all monsters', 'curse_pre': '+', 'curse_post': '%'},
-    9: {"Name": "The Royal Sampler", "Material": "Rooted Soul", "Display": "The Royal Sampler (Rooted Soul)",
+    9: {"Name": "The Royal Sampler", "Material": "Rooted Soul", "Display": "The Royal Sampler (Rooted Soul)", "MaxLevel": 20,
         "bonus_funcType": 'bigBase', 'bonus_x1': 13.5, 'bonus_x2': 1.5, 'bonus_stat': 'Printer Sample Rate', 'bonus_pre': '+', 'bonus_post': '%',
         "curse_funcType": 'bigBase', 'curse_x1': 27, 'curse_x2': 3, 'curse_stat': 'All EXP gain. Remove all samples on this character to Unequip.', 'curse_pre': '-', 'curse_post': '%'},
-    10: {"Name": "Antifun Spirit", "Material": "Rooted Soul", "Display": "Antifun Spirit (Rooted Soul)",
+    10: {"Name": "Antifun Spirit", "Material": "Rooted Soul", "Display": "Antifun Spirit (Rooted Soul)", "MaxLevel": 10,
          "bonus_funcType": 'bigBase', 'bonus_x1': 630, 'bonus_x2': 70, 'bonus_stat': 'Minigame Reward Multi', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 8.1, 'curse_x2': 0.9, 'curse_stat': 'plays per attempt', 'curse_pre': 'Minigames cost ', 'curse_post': ''},
-    11: {"Name": "Circular Criticals", "Material": "Rooted Soul", "Display": "Circular Criticals (Rooted Soul)",
+    11: {"Name": "Circular Criticals", "Material": "Rooted Soul", "Display": "Circular Criticals (Rooted Soul)", "MaxLevel": 20,
          "bonus_funcType": 'bigBase', 'bonus_x1': 9, 'bonus_x2': 1, 'bonus_stat': 'Critical Hit Chance', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 13.5, 'curse_x2': 1.5, 'curse_stat': 'Critical Damage', 'curse_pre': '-', 'curse_post': '%'},
-    12: {"Name": "Ruck Sack", "Material": "Rooted Soul", "Display": "Ruck Sack (Rooted Soul)",
+    12: {"Name": "Ruck Sack", "Material": "Rooted Soul", "Display": "Ruck Sack (Rooted Soul)", "MaxLevel": 50,
          "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Carry Capacity', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 13.5, 'curse_x2': 1.5, 'curse_stat': 'All AFK Gain Rate', 'curse_pre': '-', 'curse_post': '%'},
-    13: {"Name": "Fibers of Absence", "Material": "Frigid Soul", "Display": "Fibers of Absence (Frigid Soul)",
+    13: {"Name": "Fibers of Absence", "Material": "Frigid Soul", "Display": "Fibers of Absence (Frigid Soul)", "MaxLevel": 50,
          "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Kills for Deathnote and opening portals', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 13.5, 'curse_x2': 1.5, 'curse_stat': 'Total Damage', 'curse_pre': '-', 'curse_post': '%'},
-    14: {"Name": "Vacuous Tissue", "Material": "Frigid Soul", "Display": "Vacuous Tissue (Frigid Soul)",
+    14: {"Name": "Vacuous Tissue", "Material": "Frigid Soul", "Display": "Vacuous Tissue (Frigid Soul)", "MaxLevel": 1,
          "bonus_funcType": 'bigBase', 'bonus_x1': 100, 'bonus_x2': 0, 'bonus_stat': 'Dungeon Credits and Flurbos from Boosted Runs', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 2, 'curse_x2': 0, 'curse_stat': 'Dungeon Passes per run', 'curse_pre': 'Use ', 'curse_post': 'x'},
-    15: {"Name": "Beefy For Real", "Material": "Frigid Soul", "Display": "Beefy For Real (Frigid Soul)",
+    15: {"Name": "Beefy For Real", "Material": "Frigid Soul", "Display": "Beefy For Real (Frigid Soul)", "MaxLevel": 40,
          "bonus_funcType": 'bigBase', 'bonus_x1': 18, 'bonus_x2': 2, 'bonus_stat': 'Total Damage', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 9, 'curse_x2': 1, 'curse_stat': 'Total Defence and Accuracy', 'curse_pre': '-', 'curse_post': '%'},
-    16: {"Name": "Balance of Pain", "Material": "Squishy Soul", "Display": "Balance of Pain (Squishy Soul)",
+    16: {"Name": "Balance of Pain", "Material": "Squishy Soul", "Display": "Balance of Pain (Squishy Soul)", "MaxLevel": 30,
          "bonus_funcType": 'bigBase', 'bonus_x1': 7.2, 'bonus_x2': 0.8, 'bonus_stat': 'Multikill per Damage Tier', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 13.5, 'curse_x2': 1.5, 'curse_stat': 'Total Defence and Accuracy', 'curse_pre': '-', 'curse_post': '%'},
-    17: {"Name": "Balance of Proficiency", "Material": "Squishy Soul", "Display": "Balance of Proficiency (Squishy Soul)",
+    17: {"Name": "Balance of Proficiency", "Material": "Squishy Soul", "Display": "Balance of Proficiency (Squishy Soul)", "MaxLevel": 50,
          "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'Skill EXP Gain', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 18, 'curse_x2': 2, 'curse_stat': 'Skill Efficiency', 'curse_pre': '-', 'curse_post': '%'},
-    18: {"Name": "Glitterbug", "Material": "Squishy Soul", "Display": "Glitterbug (Squishy Soul)",
+    18: {"Name": "Glitterbug", "Material": "Squishy Soul", "Display": "Glitterbug (Squishy Soul)", "MaxLevel": 30,
          "bonus_funcType": 'bigBase', 'bonus_x1': 27, 'bonus_x2': 3, 'bonus_stat': 'chance for Giant Mobs to summon 2 Crystal Mobs', 'bonus_pre': '+', 'bonus_post': '%',
          "curse_funcType": 'bigBase', 'curse_x1': 18, 'curse_x2': 2, 'curse_stat': 'less likely to spawn', 'curse_pre': 'Giant Mobs are ', 'curse_post': '%'},
 }
@@ -6222,6 +6310,18 @@ maxStaticBookLevels = 140
 maxScalingBookLevels = 30
 maxSummoningBookLevels = 29
 maxOverallBookLevels = 100 + maxStaticBookLevels + maxScalingBookLevels + maxSummoningBookLevels
+approx_max_talent_level_non_es = (
+    maxOverallBookLevels
+    + 30  #Grimoire
+    + 25  #Equinox
+    + 20  #Arctis
+    + 15  #Symbols of Beyond
+    + 14  #ES Family Bonus (Note: Not Family Guy!)
+    + 25  #Companion: Rift Slug
+    + 5   #Sneak Mastery III
+    + 1   #Maroon Warship achievement
+)
+approx_max_talent_level_es = approx_max_talent_level_non_es + 4  #Family Guy
 dnSkullRequirementList = [0, 25000, 100000, 250000, 500000, 1000000, 5000000, 100000000, 1000000000]
 dn_miniboss_skull_requirement_list = [0, 100, 250, 1000, 5000, 25000, 100000, 1000000, 1000000000]
 dn_miniboss_names = [
@@ -6254,8 +6354,8 @@ dnNextSkullNameDict = {
     20: "Finished!"
 }
 apocableMapIndexDict = {
-    0: [30, 9, 38, 69, 120, 166],  #Barbarian only, not in regular DeathNote
-    1: [1, 2, 14, 17, 16, 13, 18, 31, 19, 24, 26, 27, 28, 8, 15],
+    0: [31, 30, 9, 38, 69, 120, 166],  #Barbarian only, not in regular DeathNote
+    1: [1, 2, 14, 17, 16, 13, 18, 19, 24, 26, 27, 28, 8, 15],  #MapIndex 31 for Brown Mushrooms was moved into 0 because they're very slow
     2: [51, 52, 53, 57, 58, 59, 60, 62, 63, 64, 65],
     3: [101, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 116, 117],
     4: [151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163],
@@ -7342,7 +7442,7 @@ caverns_conjuror_majiks = {
         {'Name': 'Resource Bursting', 'BonusPerLevel': 100, 'MaxLevel': 3, 'Scaling': 'add', 'Description': '% multi-resource max'},
         {'Name': 'Voter Integrity', 'BonusPerLevel': 6, 'MaxLevel': 5, 'Scaling': 'add', 'Description': '% larger Ballot bonus'},
         {'Name': 'Weapon Relevancy', 'BonusPerLevel': 75, 'MaxLevel': 4, 'Scaling': 'add', 'Description': '% stronger Weapon Power'},
-        {'Name': 'Equinox_Maxim', 'BonusPerLevel': 12, 'MaxLevel': 5, 'Scaling': 'value', 'Description': 'x Equinox Bar Fill Rate'},
+        {'Name': 'Equinox Maxim', 'BonusPerLevel': 12, 'MaxLevel': 5, 'Scaling': 'value', 'Description': 'x Equinox Bar Fill Rate'},
         {'Name': 'IdleOn Placeholder', 'BonusPerLevel': 1, 'MaxLevel': 2, 'Scaling': 'add', 'Description': " placeholder- Don't buy this",},
     ]
 }
@@ -8245,6 +8345,7 @@ sneaking_gemstones_all_values = {
 
 maxFarmingCrops = 230  # Last verified as of 2.26 Death Bringer
 maxFarmingValue = 10000  # Last verified as of 2.21 The Fixening
+max_land_rank_level = 11  #Base 1 + 10 from Grimoire
 landrankDict = {
     0: {'Name': 'Evolution Boost', 'UnlockLevel': 1, 'Value': 250},
     1: {'Name': 'Production Boost', 'UnlockLevel': 5, 'Value': 5},
@@ -9268,17 +9369,11 @@ reclaimableQuestItems = {
         "QuestName": "Hardcore Gamer Status, Here I Come!",
         "QuestNameCoded": "Scripticus2"
     },
-    "Quest1": {
-        "ItemName": "Mining Certificate",
+    "EquipmentTools1": {
+        "ItemName": "Junk Pickaxe",
         "QuestGiver": "Glumlee",
         "QuestName": "Literally Burning Your Money",
         "QuestNameCoded": "Glumlee3"
-    },
-    "Quest5": {
-        "ItemName": "Class Certificate",
-        "QuestGiver": "Promotheus",
-        "QuestName": "Three Right Answers",
-        "QuestNameCoded": "Promotheus2"
     },
     "InvBag4": {
         "ItemName": "Inventory Bag D",
@@ -9408,11 +9503,11 @@ slab_QuestRewardsAllChars = {
         "QuestName": "Mr. Worldwide",
         "QuestNameCoded": "Scripticus4"
     },
-    'EquipmentTools1': {
+    "EquipmentTools1": {
         "ItemName": "Junk Pickaxe",
-        "QuestGiver": "Scripticus",
-        "QuestName": "Certified Swinger, of Pickaxes of course!",
-        "QuestNameCoded": "Scripticus6"
+        "QuestGiver": "Glumlee",
+        "QuestName": "Literally Burning Your Money",
+        "QuestNameCoded": "Glumlee3"
     },
     'MaxCapBagM1': {
         "ItemName": "Mini Materials Pouch",
@@ -9467,12 +9562,6 @@ slab_QuestRewardsAllChars = {
         "QuestGiver": "Glumlee",
         "QuestName": "Learning to Swing",
         "QuestNameCoded": "Glumlee1"
-    },
-    'Quest1': {
-        "ItemName": "Mining Certificate",
-        "QuestGiver": "Glumlee",
-        "QuestName": "Literally Burning your Money",
-        "QuestNameCoded": "Glumlee3"
     },
     'MaxCapBagT2': {
         "ItemName": "Miniature Mining Pouch",

--- a/mysite/general/active.py
+++ b/mysite/general/active.py
@@ -249,13 +249,13 @@ def getLongTermAdviceList() -> list[Advice]:
 
     # SB Plunder Kills
     for killTarget in [1e3, 10e3, 32e3, 100e3, 320e3, 1e6]:
-        if killTarget > session_data.account.sb_plunder_kills:
+        if killTarget > session_data.account.class_kill_talents['Archlord of the Pirates']['Kills']:
             goalString = notateNumber("Basic", killTarget, 1)
             longterm.append(Advice(
                 label=f"Farm more Plunder Kills with Siege Breaker for Drop Rate"
                       f"<br>Crystal Setup at W5 Citringes for ~20k per day",
                 picture_class='archlord-of-the-pirates',
-                progression=notateNumber("Match", session_data.account.sb_plunder_kills, 2, '', goalString),
+                progression=notateNumber("Match", session_data.account.class_kill_talents['Archlord of the Pirates']['Kills'], 2, '', goalString),
                 goal=goalString,
                 resource='pirate-flag'
             ))
@@ -263,13 +263,13 @@ def getLongTermAdviceList() -> list[Advice]:
 
     # DK Orb Kills
     for killTarget in [1e3, 10e3, 32e3, 100e3, 320e3, 1e6]:
-        if killTarget > session_data.account.dk_orb_kills:
+        if killTarget > session_data.account.class_kill_talents['King of the Remembered']['Kills']:
             goalString = notateNumber("Basic", killTarget, 1)
             longterm.append(Advice(
                 label=f"Farm more Orb stacks with Divine Knight for Printer Output"
                       f"<br>Crystal Setup at any world you need Crystal loot from",
                 picture_class='king-of-the-remembered',
-                progression=notateNumber("Match", session_data.account.dk_orb_kills, 2, '', goalString),
+                progression=notateNumber("Match", session_data.account.class_kill_talents['King of the Remembered']['Kills'], 2, '', goalString),
                 goal=goalString,
                 resource='orb-of-remembrance'
             ))
@@ -277,13 +277,13 @@ def getLongTermAdviceList() -> list[Advice]:
 
     # ES Wormhole Kills
     for killTarget in [1e3, 10e3, 32e3, 100e3, 320e3, 1e6]:
-        if killTarget > session_data.account.es_wormhole_kills:
+        if killTarget > session_data.account.class_kill_talents['Wormhole Emperor']['Kills']:
             goalString = notateNumber("Basic", killTarget, 1)
             longterm.append(Advice(
                 label=f"Farm more Wormhole kills with Elemental Sorcerer for Damage"
                       f"<br>Generally alongside farming Rare Drops, such as Dark Lanterns",
                 picture_class='wormhole-emperor',
-                progression=notateNumber("Match", session_data.account.es_wormhole_kills, 2, '', goalString),
+                progression=notateNumber("Match", session_data.account.class_kill_talents['Wormhole Emperor']['Kills'], 2, '', goalString),
                 goal=goalString,
                 resource='dimensional-wormhole'
             ))

--- a/mysite/general/drop_rate.py
+++ b/mysite/general/drop_rate.py
@@ -1,0 +1,910 @@
+from models.models import Advice, AdviceGroup, AdviceSection
+from consts import (
+    lavaFunc, max_card_stars, maxFarmingCrops, max_land_rank_level, max_IndexOfSigils, stampsDict,
+    cards_max_level, numberOfArtifactTiers, sigilsDict, riftRewardsDict, equipment_by_bonus_dict, poBoxDict,
+    prayersDict, starsignsDict, obols_max_bonuses_dict, stamp_maxes, ValueToMulti, approx_max_talent_level_non_es, infinity_string,
+    buildingsDict, shinyDaysList
+)
+from utils.data_formatting import mark_advice_completed
+from utils.text_formatting import notateNumber
+from utils.logging import get_logger
+from math import floor, ceil
+from flask import g as session_data
+
+logger = get_logger(__name__)
+
+
+drop_rate_shiny_base = 1
+infinite_star_sign_shiny_base = 2
+
+def get_drop_rate_account_advice_group() -> AdviceGroup:
+    missing_companion_data_txt = '<br>Note: Could be inaccurate. Companion data not found!' if not session_data.account.companions['Companion Data Present'] else ''
+    missing_companion_data = not session_data.account.companions['Companion Data Present']
+    missing_bundle_data_txt = '<br>Note: Could be inaccurate. Bundle data not found!' if not session_data.account.gemshop['Bundle Data Present'] else ''
+    missing_bundle_data = not session_data.account.gemshop['Bundle Data Present']
+    passive_drop_rate_cards = [
+        'Domeo Magmus',
+        'Ancient Golem',
+        'IdleOn Fourth Anniversary'
+    ]
+
+    general = 'General'
+    mc = 'Master Classes'
+    w1 = 'World 1'
+    w2 = 'World 2'
+    w3 = 'World 3'
+    w4 = 'World 4'
+    w5 = 'World 5'
+    w6 = 'World 6'
+    drop_rate_aw_advice = {
+        general: [],
+        mc: [],
+        w1: [],
+        w2: [],
+        w3: [],
+        w4: [],
+        w5: [],
+        w6: []
+    }
+
+    #########################################
+    # Account Wide
+    #########################################
+
+    # Global
+    #########################################
+
+    # Rift - Ruby Cards
+    if not session_data.account.rift['RubyCards']:
+        ruby_cards_rift_level = next(i for i, r in riftRewardsDict.items() if r['Shorthand'] == 'RubyCards')
+        rift_level = session_data.account.rift['Level']
+        drop_rate_aw_advice[general].append(Advice(
+            label=f"Rift- Ruby Cards:"
+                  f"<br>+1 Max Card Level"
+                  f"<br>Note: increases the max card level for the cards below",
+            picture_class='ruby-cards',
+            progression=rift_level,
+            goal=ruby_cards_rift_level
+        ))
+
+    # Cards - Drop Rate
+    for card in session_data.account.cards:
+        if card.name in passive_drop_rate_cards:
+            drop_rate_aw_advice[general].append(card.getAdvice())
+
+    # Guild Bonus - Gold Charm
+    gold_charm_bonus = session_data.account.guild_bonuses['Gold Charm']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Guild Bonus- Gold Charm:"
+              f"<br>+{round(gold_charm_bonus['Value'], 2):g}/{round(gold_charm_bonus['Max Value'], 2):g}% Drop Rate",
+        picture_class=gold_charm_bonus['Image'],
+        progression=gold_charm_bonus['Level'],
+        goal=gold_charm_bonus['Max Level']
+    ))
+
+    # Upgrade Vault - Vault Mastery
+    # Temporary bonus line, disappears when maxed. Buffed value is included in the DR line below
+    vault_mastery_vault = session_data.account.vault['Upgrades']['Vault Mastery']
+    vault_mastery_vault_value_max = ValueToMulti(vault_mastery_vault['Max Level'] * vault_mastery_vault['Value Per Level'])
+    if vault_mastery_vault['Level'] < vault_mastery_vault['Max Level']:
+        drop_rate_aw_advice[general].append(Advice(
+            label=f"{{{{ Upgrade Vault|#upgrade-vault }}}}- Vault Mastery:"
+                  f"<br>{round(vault_mastery_vault['Total Value'], 2):g}/{round(vault_mastery_vault_value_max, 2):g}x blue highlighted vault bonuses"
+                  f"<br>(increases the value of the Vault upgrade below)",
+            picture_class=vault_mastery_vault['Image'],
+            progression=vault_mastery_vault['Level'],
+            goal=vault_mastery_vault['Max Level']
+        ))
+    # Upgrade Vault - Drops for Days
+    drops_for_days_vault = session_data.account.vault['Upgrades']['Drops for Days']
+    drops_for_days_vault_level_max = drops_for_days_vault['Max Level']
+    drops_for_days_vault_value_max = vault_mastery_vault_value_max * drops_for_days_vault_level_max * drops_for_days_vault['Value Per Level']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"{{{{ Upgrade Vault|#upgrade-vault }}}}- Drops for Days:"
+              f"<br>+{round(drops_for_days_vault['Total Value'], 2):g}/{round(drops_for_days_vault_value_max, 2):g}% Drop Rate",
+        picture_class=drops_for_days_vault['Image'],
+        progression=drops_for_days_vault['Level'],
+        goal=drops_for_days_vault_level_max
+    ))
+
+    # Siege Breaker - Talents -  Archlord of the Pirates
+    sb_talent = session_data.account.class_kill_talents['Archlord of the Pirates']
+    goal_string = notateNumber('Basic', 1e6, 2)
+    sb_talent_bonus_max = lavaFunc(sb_talent['funcType'], approx_max_talent_level_non_es, sb_talent['x1'], sb_talent['x2']) * sb_talent['Kill Stacks']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Siege Breaker talent- Archlord of the Pirates:"
+              f"<br>Level {sb_talent['Highest Preset Level']}/{approx_max_talent_level_non_es} with your current kills gives"
+              f"<br>{round(ValueToMulti(sb_talent['Total Value']), 5):g}/{round(ValueToMulti(sb_talent_bonus_max), 5):g}x Drop Rate MULTI",
+        picture_class='archlord-of-the-pirates',
+        progression=notateNumber('Match', sb_talent['Kills'], 2, '', goal_string),
+        goal=goal_string,
+        resource='pirate-flag'
+    ))
+
+    # Companions - Crystal Custard
+    has_crystal_custard_companion = session_data.account.companions['Crystal Custard']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Companions- Crystal Custard:"
+              f"<br>+{100 if has_crystal_custard_companion else 0}/100% Drop Rate"
+              f"{missing_companion_data_txt}",
+        picture_class='crystal-custard',
+        progression=int(has_crystal_custard_companion) if not missing_companion_data else 'IDK',
+        goal=1
+    ))
+
+    # Companions - Quenchie
+    has_quenchie_companion = session_data.account.companions['Quenchie']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Companions- Quenchie:"
+              f"<br>+{15 if has_quenchie_companion else 0}/15% Drop Rate"
+              f"{missing_companion_data_txt}",
+        picture_class='quenchie',
+        progression=int(has_quenchie_companion) if not missing_companion_data else 'IDK',
+        goal=1
+    ))
+
+    # Companions - Mallay
+    has_mallay_companion = session_data.account.companions['Mallay']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Companions- Mallay:"
+              f"<br>{1.3 if has_mallay_companion else 0}/1.3x Drop Rate MULTI"
+              f"{missing_companion_data_txt}",
+        picture_class='mallay',
+        progression=int(has_mallay_companion) if not missing_companion_data else 'IDK',
+        goal=1
+    ))
+
+    # Gem Shop - Deathbringer Pack
+    has_db_pack = session_data.account.gemshop['Bundles']['bun_v']['Owned']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Gemshop- Deathbringer Pack:"
+              f"<br>+{200 if has_db_pack else 0}/200% Drop Rate"
+              f"{missing_bundle_data_txt}",
+        picture_class='gem',
+        progression=int(has_db_pack) if not missing_bundle_data else 'IDK',
+        goal=1
+    ))
+
+    # Gem Shop - Island Explorer Pack
+    has_island_explorer_pack = session_data.account.gemshop['Bundles']['bun_p']['Owned']
+    drop_rate_aw_advice[general].append(Advice(
+        label=f"Gemshop- Island Explorer Pack:"
+              f"<br>{1.2 if has_island_explorer_pack else 0}/1.2x Drop Rate MULTI"
+              f"{missing_bundle_data_txt}",
+        picture_class='gem',
+        progression=int(has_island_explorer_pack) if not missing_bundle_data else 'IDK',
+        goal=1
+    ))
+
+    # Master Classes
+    #########################################
+    # Grimoire - Skull of Major Droprate
+    skull_drop_rate_grimoire = session_data.account.grimoire['Upgrades']['Skull of Major Droprate']
+    skull_drop_rate_grimoire_upgrades_unlock = skull_drop_rate_grimoire['Unlock Requirement'] - session_data.account.grimoire['Total Upgrades']
+    drop_rate_aw_advice[mc].append(Advice(
+        label=f"{{{{Grimoire|#the-grimoire}}}}- Skull of Major Droprate:"
+              f"<br>+{round(skull_drop_rate_grimoire['Total Value'], 1):g}% Drop Rate"
+              f"{f'<br>Requires {skull_drop_rate_grimoire_upgrades_unlock} more upgrades to unlock' if skull_drop_rate_grimoire_upgrades_unlock > 0 else ''}",
+        picture_class=skull_drop_rate_grimoire['Image'],
+        progression=skull_drop_rate_grimoire['Level'],
+        goal=skull_drop_rate_grimoire['Max Level']
+    ))
+
+    # World 1
+    #########################################
+
+    # Owl Bonuses
+    drop_rate_aw_advice[w1].append(Advice(
+        label=f"{{{{ Owl|#owl }}}}- Drop Rate:"
+              f"<br>+{session_data.account.owl['Bonuses']['Drop Rate']['Value']}% Drop Rate",
+        picture_class='the-great-horned-owl',
+        progression=max(0, session_data.account.owl['MegaFeathersOwned']-10),
+        resource='megafeather-9',
+        goal=infinity_string
+    ))
+
+    # Lab Nodes- Certified Stamp Book
+    # Temporary bonus line, disappears when maxed. Buffed value is included in the DR line below
+    golden_sixes_buffs = []
+    has_certified_stamp_book = session_data.account.labBonuses['Certified Stamp Book']['Enabled']
+    if not has_certified_stamp_book:
+        golden_sixes_buffs.append('Lab')
+        drop_rate_aw_advice[w1].append(Advice(
+            label=f"{{{{ Lab Nodes|#lab }}}}- Certified Stamp Book:"
+                  "<br>x2 Non-Misc Stamp Bonuses"
+                  "<br>Note: Improves the stamp below",
+            picture_class='certified-stamp-book',
+            progression=int(has_certified_stamp_book),
+            goal=1
+        ))
+    # Pristine Charm- Liqorice Rolle
+    # Temporary bonus line, disappears when maxed. Buffed value is included in the DR line below
+    has_liqorice_rolle = session_data.account.sneaking['PristineCharms']['Liqorice Rolle']['Obtained']
+    if not has_liqorice_rolle:
+        golden_sixes_buffs.append('Pristine Charm')
+        drop_rate_aw_advice[w1].append(Advice(
+            label="Pristine Charms- Liqorice Rolle:"
+                  f"<br>{1.25 if has_liqorice_rolle else 0}/1.25x Non Misc Stamp Bonuses"
+                  "<br>Note: improves the stamp below",
+            picture_class='liqorice-rolle',
+            progression=int(has_liqorice_rolle),
+            goal=1
+        ))
+    # Stamps - Golden Sixes
+    golden_sixes_stamp = session_data.account.stamps['Golden Sixes Stamp']
+    if not golden_sixes_stamp['Exalted']:
+        golden_sixes_buffs.append('Exalting the stamp')
+    if len(golden_sixes_buffs) == 0:
+        golden_sixes_addl_text = f"Note: Can be further increased by Exalted {{{{Stamp|#stamps}}}} bonuses"
+    else:
+        golden_sixes_addl_text = f"Note: Can be increased by " + ", ".join(golden_sixes_buffs)
+
+    golden_sixes_stamp_data = stampsDict['Combat'][37]
+    golden_sixes_max_base = lavaFunc(golden_sixes_stamp_data['funcType'], stamp_maxes['Golden Sixes Stamp'], golden_sixes_stamp_data['x1'], golden_sixes_stamp_data['x2'])
+    drop_rate_aw_advice[w1].append(Advice(
+        label=f"{{{{ Stamps|#stamps }}}}- Golden Sixes:"
+              f"<br>+{round(golden_sixes_stamp['Total Value'], 2):g}% Drop Rate"
+              f"<br>{golden_sixes_addl_text}",
+        picture_class='golden-sixes-stamp',
+        progression=golden_sixes_stamp['Level'],
+        resource=golden_sixes_stamp['Material'],
+        goal=stamp_maxes['Golden Sixes Stamp'] if golden_sixes_stamp['Delivered'] else 1
+    ))
+
+    # World 2
+    #########################################
+
+    # Arcade - Shop Bonuses
+    has_reindeer_companion = session_data.account.companions['Reindeer']
+    if not has_reindeer_companion:
+        drop_rate_aw_advice[w2].append(Advice(
+            label=f"Companions- Reindeer:"
+                  f"<br>{2 if has_reindeer_companion else 0}/2x Arcade Bonus MULTI"
+                  f"<br>Note: Increases the Arcade Bonus value below"
+                  f"{missing_companion_data_txt}",
+            picture_class='spirit-reindeer',
+            progression=int(has_reindeer_companion) if not missing_companion_data else 'IDK',
+            goal=1
+        ))
+
+    drop_rate_arcade = session_data.account.arcade[27]
+    drop_rate_aw_advice[w2].append(Advice(
+        label=f"{{{{ Arcade|#arcade }}}}- Drop Rate:"
+              f"<br>+{drop_rate_arcade['Value']:g}/{drop_rate_arcade['MaxValue']:g}% Drop Rate"
+              f"{missing_companion_data_txt}",
+        picture_class=drop_rate_arcade['Image'],
+        progression=drop_rate_arcade['Level'],
+        resource='arcade-gold-ball',
+        goal=101
+    ))
+
+    # Obols - Family - Drop Rate
+    obols_family_drop_rate = session_data.account.obols['BonusTotals'].get('Total%_DROP_CHANCE', 0)
+    obols_family_drop_rate_max = obols_max_bonuses_dict['FamilyDropRateTrue']
+    obols_family_note = '<br>Note: Includes Rare and Hyper Obols, each rerolled with +1% DR'
+    drop_rate_aw_advice[w2].append(Advice(
+        label=f"Obols- Family Obols:"
+              f"<br>+{obols_family_drop_rate}/{obols_family_drop_rate_max}% Drop Rate"
+              f"{obols_family_note}",
+        picture_class='hyper-six-obol',
+        progression=obols_family_drop_rate,
+        goal=obols_family_drop_rate_max
+    ))
+
+    # Question: Maybe up the goal to 6930 for +39.6% at 99% or 2730 for a nice round +39%?
+    # Alchemy - Bubbles - Dropin Loads
+    dropin_loads_bubble = session_data.account.alchemy_bubbles['Droppin Loads']
+    droppin_loads_value_breakpoints = [
+        [280, 32, 80],
+        [630, 36, 90],
+        [1330, 38, 95],
+        [6930, 39.6, 99]
+    ]
+    droppin_loads_next_breakpoint = next(
+        (b for b in droppin_loads_value_breakpoints if b[0] > dropin_loads_bubble['Level']),
+        None
+    )
+    droppin_loads_breakpoint_txt = (
+        f"<br>Next breakpoint: {droppin_loads_next_breakpoint[2]}% value at level {droppin_loads_next_breakpoint[0]}"
+        if droppin_loads_next_breakpoint is not None else ''
+    )
+    drop_rate_aw_advice[w2].append(Advice(
+        label=f"{{{{ Alchemy Bubbles|#bubbles }}}}- Droppin Loads:"
+              f"<br>+{round(dropin_loads_bubble['BaseValue'], 2):g}/{droppin_loads_value_breakpoints[-1][1]}% Drop Rate"
+              f"{droppin_loads_breakpoint_txt}",
+        picture_class='droppin-loads',
+        progression=dropin_loads_bubble['Level'],
+        resource=dropin_loads_bubble['Material'],
+        goal=droppin_loads_value_breakpoints[-1][0]
+    ))
+
+    # Artifacts- Chilled Yarn
+    # Temporary bonus line, disappears when maxed. Buffed value is included in the DR line below
+    chilled_yarn_artifact_level = session_data.account.sailing['Artifacts']['Chilled Yarn']['Level']
+    chilled_yarn_multi = ValueToMulti(100 * session_data.account.sailing['Artifacts']['Chilled Yarn']['Level'])
+    chilled_yarn_max = ValueToMulti(100 * numberOfArtifactTiers)
+    if chilled_yarn_artifact_level < numberOfArtifactTiers:
+        drop_rate_aw_advice[w2].append(Advice(
+            label=f"{{{{ Artifacts|#artifacts }}}}- Chilled Yarn:"
+                  f"<br>{round(chilled_yarn_multi, 2):g}/{round(chilled_yarn_max, 2):g}x Sigil Bonuses"
+                  f"<br>Note: Improves the sigil below",
+            picture_class='chilled-yarn',
+            progression=chilled_yarn_artifact_level,
+            goal=numberOfArtifactTiers
+        ))
+    # Alchemy - Sigils - Clover
+    trove_sigil_level = session_data.account.alchemy_p2w['Sigils']['Trove']['Level']
+    trove_sigil_value = sigilsDict['Trove']['Values'][trove_sigil_level-1] * chilled_yarn_multi
+    trove_sigil_value_max = sigilsDict['Trove']['Values'][max_IndexOfSigils-1] * chilled_yarn_max
+    drop_rate_aw_advice[w2].append(Advice(
+        label=f"{{{{ Sigils|#sigils }}}}- Clover Sigil:"
+              f"<br>+{trove_sigil_value}/{trove_sigil_value_max}% Drop Rate",
+        picture_class='trove',
+        progression=trove_sigil_level,
+        goal=max_IndexOfSigils
+    ))
+
+    # World 3
+    #########################################
+
+    # Equinox - Faux Jewels
+    # Will show additional info if player is maxed out for their currently available levels
+    faux_jewels_bonus = session_data.account.equinox_bonuses['Faux Jewels']
+    faux_jewels_level = faux_jewels_bonus['CurrentLevel']
+    faux_jewels_max_current = max(faux_jewels_bonus['FinalMaxLevel'], faux_jewels_bonus['PlayerMaxLevel'])
+    faux_jewels_at_current_max = faux_jewels_level == faux_jewels_bonus['PlayerMaxLevel'] and faux_jewels_bonus['PlayerMaxLevel'] != 0
+    drop_rate_aw_advice[w3].append(Advice(
+        label=f"{{{{ Equinox|#equinox }}}}- Faux Jewels:"
+              f"<br>+{5 * faux_jewels_level}/{5 * faux_jewels_max_current}% Drop Rate (+5% per level)"
+              f"{'<br>Note: Increase Faux Jewels max level with {{Endless Summoning|#summoning}}' if faux_jewels_at_current_max else ''}",
+        picture_class='faux-jewels',
+        progression=faux_jewels_level,
+        # This is technically infinite with Endless Summoning wins, but we'll just show what's currently unlocked with a note about ES
+        goal=faux_jewels_max_current
+    ))
+
+    # Construction - Shrine - Clover Shrine
+    chaotic_chizoar_card = next(c for c in session_data.account.cards if c.name == 'Chaotic Chizoar')
+    shrine_exta_bonus_text = ''
+    if chaotic_chizoar_card.getStars() < (cards_max_level-1):
+        drop_rate_aw_advice[w3].append(chaotic_chizoar_card.getAdvice())
+        shrine_exta_bonus_text = '<br>Note: Can be increased by getting more Chaotic Chizoar card stars'
+    drop_rate_aw_advice[w3].append(Advice(
+        label=f"Shrines- Clover Shrine:"
+              f"<br>+{round(session_data.account.shrines['Clover Shrine']['Value'], 2):g}% Drop Rate "
+              f"({buildingsDict[22]['ValueBase']}% base + {buildingsDict[22]['ValueIncrement']}% per level)"
+              f"{shrine_exta_bonus_text}",
+        picture_class='clover-shrine',
+        progression=session_data.account.shrines['Clover Shrine']['Level'],
+        goal=infinity_string
+    ))
+
+    # World 4
+    #########################################
+
+    # Breeding - Shiny Pets
+    for world in session_data.account.breeding['Species']:
+        for shiny_name, shiny_details in session_data.account.breeding['Species'][world].items():
+            if shiny_details['ShinyBonus'] == 'Drop Rate':
+                drop_rate_aw_advice[w4].append(Advice(
+                    label=f"{{{{ Breeding|#breeding }}}}- Shiny {shiny_name}: +{shiny_details['ShinyLevel']}/{len(shinyDaysList)}%",
+                    picture_class=shiny_name,
+                    progression=shiny_details['ShinyLevel'],
+                    goal=len(shinyDaysList)
+                ))
+
+    # Rift - Sneak Mastery 1
+    sneak_mastery_level = session_data.account.sneaking['MaxMastery']
+    drop_rate_aw_advice[w4].append(Advice(
+        label=f"{{{{ Rift|#rift }}}}- Sneaking Mastery:"
+              f"<br>+{30 if (sneak_mastery_level > 0) else 0}/30% Drop Rate",
+        picture_class='sneaking-mastery',
+        progression=min(1, sneak_mastery_level),
+        goal=1
+    ))
+
+    # The Tome
+    # Temporary bonus line, disappears when maxed. Buffed value is included in the DR line below
+    grey_tome_book = session_data.account.grimoire['Upgrades']['Grey Tome Book']
+    if grey_tome_book['Level'] < grey_tome_book['Max Level']:
+        upgrades_to_unlock = grey_tome_book['Unlock Requirement'] - session_data.account.grimoire['Total Upgrades']
+        drop_rate_aw_advice[w4].append(Advice(
+            label=f"{{{{Grimoire|#the-grimoire}}}}: Grey Tome Book:"
+                  f"<br>{round(grey_tome_book['Total Value'], 2):g}x higher bonus from Tome Red Pages"
+                  f"{f'<br>Requires {upgrades_to_unlock} more upgrades to unlock' if upgrades_to_unlock > 0 else ''}",
+            picture_class=session_data.account.grimoire['Upgrades']['Grey Tome Book']['Image'],
+            progression=grey_tome_book['Level'],
+            goal=grey_tome_book['Max Level']
+        ))
+    drop_rate_aw_advice[w4].append(Advice(
+        label=f"""Tome- Red Pages:"""
+              f"""<br>+{round(session_data.account.tome['Bonuses']['Drop Rarity']['Total Value'], 3):g}% Drop Rate"""
+              f"""<br>{'Unknown, sorry 🙁' if not session_data.account.tome['Data Present'] else ''}"""
+              f"""{f"{session_data.account.tome['Total Points']:,}" if session_data.account.tome['Data Present'] else ''} Total Tome Points"""
+              f"""<br>Increases every 100 points over 8000""",
+        picture_class='red-tome-pages',
+        progression=session_data.account.tome['Red Pages Unlocked'],
+        goal=1
+    ))
+
+    # World 5
+    #########################################
+
+    # Caverns - Measurments - Yards
+    caverns_measurements_yards = session_data.account.caverns['Measurements'][15]
+    drop_rate_aw_advice[w5].append(Advice(
+        label=f"{{{{ Caverns|#villagers }}}}: Measurement 15:"
+              f"<br>+{round(caverns_measurements_yards['Value'], 1):g}% Drop Rate (scales with {caverns_measurements_yards['ScalesWith']})",
+        picture_class=caverns_measurements_yards['Image'],
+        progression=caverns_measurements_yards['Level'],
+        goal=infinity_string
+    ))
+
+    # Caverns - Schematics - Gloomie Lootie
+    grotto_cavern = session_data.account.caverns['Caverns']['Grotto']
+    gloomie_lootie_schematic = session_data.account.caverns['Schematics']['Gloomie Lootie']
+    drop_rate_aw_advice[w5].append(Advice(
+        label=f"{{{{ Caverns|#villagers }}}}: Schematic {gloomie_lootie_schematic['UnlockOrder']}: Gloomie Lootie:"
+              f"<br>+{5 * grotto_cavern['OpalsFound']}% Drop Rate (+5% per Cavern cleared)",
+        picture_class=gloomie_lootie_schematic['Image'],
+        progression=grotto_cavern['OpalsFound'] if gloomie_lootie_schematic['Purchased'] else 0,
+        goal=infinity_string
+    ))
+
+    # Caverns - Schematics - Sanctum of LOOT
+    temple_cavern = session_data.account.caverns['Caverns']['The Temple']
+    sanctum_of_loot_schematic = session_data.account.caverns['Schematics']['Sanctum of LOOT']
+    drop_rate_aw_advice[w5].append(Advice(
+        label=f"{{{{ Caverns|#villagers }}}}: Schematic {sanctum_of_loot_schematic['UnlockOrder']}: Sanctum of LOOT:"
+              f"<br>+{20 * temple_cavern['OpalsFound']}% Drop Rate (+20% per Sanctum cleared)",
+        picture_class=sanctum_of_loot_schematic['Image'],
+        progression=temple_cavern['OpalsFound'] if sanctum_of_loot_schematic['Purchased'] else 0,
+        goal=infinity_string
+    ))
+
+    # Caverns - Wisdom Monument
+    wisdom_drop_rate_index = 26
+    wisdom_monument_drop_rate = session_data.account.caverns['Caverns']['Wisdom Monument']['Bonuses'][wisdom_drop_rate_index]
+    drop_rate_aw_advice[w5].append(Advice(
+        label=f"{{{{ Cavern 13|#underground-overgrowth }}}}: Wisdom Monument:"
+              f"<br>+{round(wisdom_monument_drop_rate['Value'], 2):g}% Drop Rate",
+        picture_class='cavern-13',
+        progression=wisdom_monument_drop_rate['Level'],
+        goal=infinity_string
+    ))
+
+    # World 6
+    #########################################
+
+    # Achievements - Big Big Hampter
+    big_hampter_completed = session_data.account.achievements['Big Big Hampter']['Complete']
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Achievements|#achievements }}}}- Big Big Hampter:"
+              f"<br>+{4 if big_hampter_completed else 0}/4% Drop Rate",
+        picture_class='big-big-hampter',
+        progression=int(big_hampter_completed),
+        goal=1
+    ))
+
+    # Achievements - Summoning GM
+    summoning_gm_completed = session_data.account.achievements['Summoning GM']['Complete']
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Achievements|#achievements }}}}- Summoning GM:"
+              f"<br>+{6 if summoning_gm_completed else 0}/6% Drop Rate",
+        picture_class='summoning-gm',
+        progression=int(summoning_gm_completed),
+        goal=1
+    ))
+
+    # Farming - Crop Depot - Highlighter
+    crops_unlocked = session_data.account.farming['CropsUnlocked']
+    highlighter = session_data.account.farming['Depot'][7]
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Farming Crop Depot|#farming }}}}- Highlighter:"
+              f"<br>+{round(highlighter['Value'], 2):g}% Drop Rate"
+              f"{'<br>Note: Value only increases after 100 crops found' if (crops_unlocked <= 100) else ''}",
+        picture_class=highlighter['Image'],
+        progression=crops_unlocked,
+        goal=maxFarmingCrops
+    ))
+
+    # Farming - Land Rank - Seed of Loot
+    # Will show additional info if the player does not have the current max number of available land rank levels
+    seed_of_loot_land_rank = session_data.account.farming['LandRankDatabase']['Seed of Loot']
+    seed_of_loot_value = seed_of_loot_land_rank['BaseValue'] * seed_of_loot_land_rank['Level']
+    seed_of_loot_value_max = seed_of_loot_land_rank['BaseValue'] * max_land_rank_level
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Land Ranks|#farming }}}}- Seed of Loot:"
+              f"<br>+{seed_of_loot_value}/{seed_of_loot_value_max}% Drop Rate"
+              f"{f'<br>Note: Increase Land Rank max with Death Bringer {{{{ Grimoire|#the-grimoire }}}}' if seed_of_loot_land_rank['Level'] < max_land_rank_level else ''}",
+        picture_class='seed-of-loot',
+        progression=seed_of_loot_land_rank['Level'],
+        goal=max_land_rank_level
+    ))
+
+    # Sneaking - Pristine Charm - Cotton Candy
+    cotton_candy_obtained = session_data.account.sneaking['PristineCharms']['Cotton Candy']['Obtained']
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Pristine Charms|#sneaking }}}}- Cotton Candy:"
+              f"<br>{1.15 if cotton_candy_obtained else 0}/1.15x Drop Rate MULTI",
+        picture_class='cotton-candy-charm',
+        progression=int(cotton_candy_obtained),
+        goal=1
+    ))
+
+    # Sneaking - Beanstalk - Golden Cake
+    beanstack_requirements = [0, '10K', '100K']
+    cake_beanstalk = session_data.account.sneaking['Beanstalk']['FoodG13']
+    cake_beanstalk_level = int(cake_beanstalk['Beanstacked']) + int(cake_beanstalk['SuperBeanstacked'])
+    if cake_beanstalk_level == 2:
+        cake_beanstalk_bonus = '+6.67'
+    elif cake_beanstalk_level == 1:
+        cake_beanstalk_bonus = '+4.59'
+    else:
+        cake_beanstalk_bonus = '0'
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Beanstalk|#beanstalk }}}}- Golden Cake:"
+              f"<br>{cake_beanstalk_bonus}/6.67% base Drop Rate from {beanstack_requirements[cake_beanstalk_level]} deposited"
+              f"<br>Note: Further increased by Golden Food bonuses",
+        picture_class='golden-cake',
+        progression=cake_beanstalk_level,
+        goal=2
+    ))
+
+    # Summoning - Bonuses
+    summoning_battles = session_data.account.summoning['Battles']
+    yellow_3_drop_rate = 7 if summoning_battles['Yellow'] >= 3 else 0
+    blue_9_drop_rate = 10.5 if summoning_battles['Blue'] >= 9 else 0
+    purple_12_drop_rate = 17.5 if summoning_battles['Purple'] >= 12 else 0
+    red_13_drop_rate = 35 if summoning_battles['Red'] >= 13 else 0
+    summoning_drop_rate_base = yellow_3_drop_rate + blue_9_drop_rate + purple_12_drop_rate + red_13_drop_rate
+    endless_summon_bonus_multi = .03 * ((floor(summoning_battles['Endless']/40) * 2) + (1 if summoning_battles['Endless'] % 40 > 16 else 0))
+    other_summon_bonus_multi = (
+        (.01 if session_data.account.achievements['Regalis My Beloved']['Complete'] else 0)
+        + (.01 if session_data.account.achievements['Spectre Stars']['Complete'] else 0)
+        + (.25 * session_data.account.sailing['Artifacts']['The Winz Lantern']['Level'])
+        + (.01 * session_data.account.merits[5][4]['Level'])
+    )
+    prisine_charm_summon_bonus_multi = 1.3 if session_data.account.sneaking['PristineCharms']['Crystal Comb']['Obtained'] else 1
+    # The bonuses from endless summoning and everything else, except the pristine charm are addative. The charm is a multi
+    total_summon_bonus_multi = (1 + endless_summon_bonus_multi + other_summon_bonus_multi) * prisine_charm_summon_bonus_multi
+    summoning_drop_rate_value = round(summoning_drop_rate_base * total_summon_bonus_multi, 2)
+    summoning_drop_rate_max_base = 7 + 10.5 + 17.5 + 35
+    summoning_drop_rate_max_modded = round(summoning_drop_rate_max_base * total_summon_bonus_multi, 2)
+    drop_rate_aw_advice[w6].append(Advice(
+        label=f"{{{{ Summoning Bonuses|#summoning }}}}- Drop Rate:"
+              f"<br>+{summoning_drop_rate_value:g}/{summoning_drop_rate_max_modded:g}% Drop Rate"
+              f"{f'<br>Note: Max value can be further increased with Endless Summoning wins' if summoning_drop_rate_value >= summoning_drop_rate_max_base else ''}",
+        picture_class='summoning',
+        progression=summoning_battles['Endless'],
+        goal=infinity_string
+    ))
+
+    for subgroup in drop_rate_aw_advice:
+        for advice in drop_rate_aw_advice[subgroup]:
+            mark_advice_completed(advice)
+
+    drop_rate_ag = AdviceGroup(
+        tier="",
+        pre_string="Info- Account wide sources of Drop Rate",
+        post_string="Note: External DR bonus modifiers are included in Values shown, but only listed if missing or not maxed.",
+        advices=drop_rate_aw_advice,
+        informational=True,
+    )
+    return drop_rate_ag
+
+def get_drop_rate_player_advice_group():
+    # All of the cards that affect Drop Rate
+    drop_rate_cards = [
+        'Emperor',
+        'Minichief Spirit',
+        'King Doot',
+        'Mister Brightside',
+        'Crystal Carrot',
+        'Bop Box',
+        'Mr Blueberry',
+        'Giftmas Blobulyte',
+        'Mimic'
+    ]
+
+    bnn_cardset = []
+    events_cardset = []
+    for card in session_data.account.cards:
+        if card.cardset == 'Bosses n Nightmares':
+            bnn_cardset.append(card)
+        if card.cardset == 'Events':
+            events_cardset.append(card)
+
+    cards = 'Cards'
+    eqp = 'Equipment'
+    misc = 'Miscellaneous'
+    drop_rate_pp_advice = {
+        cards: [],
+        eqp: [],
+        misc: []
+    }
+
+    # Cards - Drop Rate
+    # Considered just showing the best 8, either total or currently unlocked
+    # But decided to just show all of them so new accounts can see what they don't have yet
+    card_drop_rate = []
+    for card in session_data.account.cards:
+        if card.name in drop_rate_cards:
+            card_drop_rate.append(card)
+    best_2_cards = 0
+    for card in sorted(card_drop_rate, key=lambda c: c.getCurrentValue(), reverse=True):
+        end_note = ''
+        if best_2_cards < 2:
+            if best_2_cards == 0 and session_data.account.labChips['Omega Nanochip'] > 0:
+                end_note = 'Note: Place in TOP LEFT card slot with Omega Nanochip Lab Chip'
+            elif best_2_cards != 0 and session_data.account.labChips['Omega Motherboard'] > 0:
+                end_note = 'Note: Place in BOT RIGHT card slot with Omega Motherboard Lab Chip'
+            best_2_cards += 1
+        drop_rate_pp_advice[cards].append(card.getAdvice(optional_ending_note=end_note))
+
+    # Card Sets - Bosses n Nightmares
+    bnn_stars_sum = sum(min(card.star, max_card_stars) + 1 for card in bnn_cardset)
+    bnn_star, _ = divmod(bnn_stars_sum, len(bnn_cardset))
+    bnn_star = min(bnn_star, max_card_stars)
+    bnn_star_next = (bnn_star + 1) * len(bnn_cardset)
+    if bnn_stars_sum == bnn_star_next:
+        bnn_star += 1
+    drop_rate_pp_advice[cards].append(Advice(
+        label=f"{{{{ Card Sets|#cards }}}}- Bosses n Nightmares:"
+              f"<br>+{6 * bnn_star}/{6 * (1 + max_card_stars)}% Drop Rate"
+              + (f"<br>Cards until next set level {bnn_stars_sum}/{bnn_star_next}" if bnn_stars_sum < bnn_star_next else '')
+        ,
+        picture_class='bosses-n-nightmares',
+        progression=bnn_star,
+        goal=6
+    ))
+
+    # Cards Sets - Events
+    events_stars_sum = sum(min(card.star, max_card_stars) + 1 for card in events_cardset)
+    events_star, _ = divmod(events_stars_sum, len(events_cardset))
+    events_star = min(events_star, max_card_stars)
+    events_star_next = (events_star + 1) * len(events_cardset)
+    if events_stars_sum == events_star_next:
+        events_star += 1
+    drop_rate_pp_advice[cards].append(Advice(
+        label=f"{{{{ Card Sets|#cards }}}}- Events:"
+              f"<br>+{7 * events_star}/{7 * (1 + max_card_stars)}% Drop Rate"
+              + (f"<br>Cards until next set level {events_stars_sum}/{events_star_next}" if events_stars_sum < events_star_next else ''),
+        picture_class='events',
+        progression=events_star,
+        goal=6
+    ))
+
+    drop_rate_equipment = {}
+    for equipment_name, equipment_data in equipment_by_bonus_dict['DropRate'].items():
+        equipment_drop_rate = 0
+        if equipment_data.get('Misc1', False) and equipment_data['Misc1']['Bonus'] == 'DropRate':
+            equipment_drop_rate = equipment_data['Misc1']['Value']
+        elif equipment_data.get('Misc2', False) and equipment_data['Misc2']['Bonus'] == 'DropRate':
+            equipment_drop_rate = equipment_data['Misc2']['Value']
+        if not drop_rate_equipment.get(equipment_data['Type'], False):
+            drop_rate_equipment[equipment_data['Type']] = []
+        drop_rate_equipment[equipment_data['Type']].append({
+            'Name': equipment_name,
+            'Limited': equipment_data['Limited'],
+            'Type': equipment_data['Type'],
+            'Owned': next((a.amount > 0 for a in session_data.account.all_assets.values() if a.name == equipment_name), False),
+            'Value': equipment_drop_rate,
+            'Image': equipment_data['Image'],
+            'Note': equipment_data.get('Note', '')
+        })
+
+    # Equipment - Drop Rate
+    for slot_list in drop_rate_equipment.values():
+        # Once the player has a piece of DR gear for a slot, it won't list _worse_ items for the same slot.
+        # Each slot is already sorted best to worst so we just break out of the slot loop once we have an owned item
+        # Because of the lack of availability, we'll show ALL limited items all the time. Even if something better is owned
+        best_value = 0
+        for equipment in sorted(slot_list, key=lambda e: e['Value'], reverse=True):
+            if equipment['Value'] >= best_value:
+                best_value = max(best_value, equipment['Value'] * equipment['Owned'])
+                drop_rate_pp_advice[eqp].append(Advice(
+                    label=f"{equipment['Type']}- {equipment['Name']}:"
+                          f"<br>+{equipment['Value']}% Drop Rate{' (Limited availability)' if equipment['Limited'] else ''}"
+                          f"{'<br>' + equipment['Note'] if equipment['Note'] else ''}",
+                    picture_class=equipment['Image'],
+                    progression=int(equipment['Owned']),
+                    goal=1
+                ))
+
+    # Lab Chips - Silkrode Nanochip
+    # Modifier for Star Signs below, must be equipped so we always show 
+    silkroad_chip_owned = session_data.account.labChips['Silkrode Nanochip'] > 0
+    silkroad_chip_starsign_mod = 2 if silkroad_chip_owned else 1
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"Lab Chips- Silkrode Nanochip:"
+              f"<br>x2 Star Sign Bonuses while equipped"
+              f"<br>Note: Improves the Star Signs below while they are equipped",
+        picture_class='silkrode-nanochip',
+        progression=int(silkroad_chip_owned),
+        goal=1
+    ))
+
+    # Star Signs - Seraph Cosmos
+    # Always shown because the modifier can grow based on Summoning levels
+    saraph_cosmos_starsign_unlocked = session_data.account.star_signs['Seraph Cosmos']['Unlocked']
+    saraph_cosmod_starsign_mod = (1.1 ** max(3, ceil((session_data.account.all_skills['Summoning'][0]+1)/20))) if saraph_cosmos_starsign_unlocked else 1.0
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"{{{{ Star Signs|#star-signs }}}}- Seraph Cosmos:"
+              f"<br>x{round(saraph_cosmod_starsign_mod, 3)} Star Sign Bonuses (x1.10 per 20 Summoning levels)"
+              f"<br>Note: Always improves the Star Signs below",
+        picture_class='seraph-cosmos',
+        progression=int(saraph_cosmos_starsign_unlocked),
+        goal=1
+    ))
+
+    # Add up Infinite Star Sign levels
+    infinite_star_sign_levels = 0
+    for world_species in session_data.account.breeding['Species'].values():
+        for pet_species in world_species.values():
+            if pet_species['ShinyBonus'] == 'Infinite Star Signs':
+                infinite_star_sign_levels += infinite_star_sign_shiny_base * pet_species['ShinyLevel']
+    
+    # Passive Star Signs are skipped by infinite star signs. The easiest way to account for this is to
+    # just +1 the total ISS for each passive that WOULD have been counted. Then we can just compare index to ISS
+    i = 1
+    while i < min(len(starsignsDict), infinite_star_sign_levels):
+        infinite_star_sign_levels += int(starsignsDict[i]['Passive'])
+        i += 1
+
+    # Star Sign - Pirate Booty
+    pirate_booty_starsign = session_data.account.star_signs['Pirate Booty']
+    pirate_booty_starsign_unlocked = pirate_booty_starsign['Unlocked']
+    pirate_booty_infinite_unlocked = pirate_booty_starsign['Index'] <= infinite_star_sign_levels
+    pirate_booty_starsign_value_nochip = 5 * saraph_cosmod_starsign_mod
+    pirate_booty_starsign_value_chip = 5 * saraph_cosmod_starsign_mod * silkroad_chip_starsign_mod
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"{{{{ Star Signs|#star-signs }}}}- Pirate Booty:"
+              f"<br>+{round(pirate_booty_starsign_value_nochip, 1):g}% Drop Rate {'PASSIVE' if pirate_booty_infinite_unlocked else 'if equipped'}"
+              f"{f'<br>+{round(pirate_booty_starsign_value_chip, 1):g}% Drop Rate if equipped WITH Silkrode Lab Chip' if silkroad_chip_owned and pirate_booty_infinite_unlocked else ''}",
+        picture_class='blue-hedgehog',
+        progression=int(pirate_booty_starsign_unlocked),
+        goal=1
+    ))
+
+    # Star Sign - Druipi Major
+    druipi_majox_starsign = session_data.account.star_signs['Druipi Major']
+    druipi_major_starsign_unlocked = druipi_majox_starsign['Unlocked']
+    druipi_major_infinite_unlocked = druipi_majox_starsign['Index'] <= infinite_star_sign_levels
+    druipi_major_starsign_value_nochip = 12 * saraph_cosmod_starsign_mod
+    druipi_major_starsign_value_chip = 12 * saraph_cosmod_starsign_mod * silkroad_chip_starsign_mod
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"{{{{ Star Signs|#star-signs }}}}- Druipi Major:"
+              f"<br>+{round(druipi_major_starsign_value_nochip, 1):g}% Drop Rate {'PASSIVE' if druipi_major_infinite_unlocked else 'if equipped'}"
+              f"{f'<br>+{round(druipi_major_starsign_value_chip, 1):g}% Drop Rate if equipped WITH Silkrode Lab Chip' if silkroad_chip_owned and druipi_major_infinite_unlocked else ''}",
+        picture_class='og-signalais',
+        progression=int(druipi_major_starsign_unlocked),
+        goal=1
+    ))
+
+    # Post Office - Non Predatory Loot Box
+    nplb = next(b for b in poBoxDict.values() if b['Name'] == 'Non Predatory Loot Box')
+    nplb_dr_max_value = lavaFunc(
+        funcType=nplb['1_funcType'],
+        level=nplb['Max Level'],
+        x1=nplb['1_x1'],
+        x2=nplb['1_x2']
+    )
+    nplb_all = [char.po_boxes_invested[nplb['Name']]['Level'] for char in session_data.account.all_characters]
+    nplb_unmaxed = {char.character_name:char.po_boxes_invested[nplb['Name']]['Level'] for char in session_data.account.all_characters if char.po_boxes_invested['Non Predatory Loot Box']['Level'] < nplb['Max Level']}
+    nplb_lowest = min(nplb_all, default=0)
+    if nplb_lowest < nplb['Max Level']:
+        drop_rate_pp_advice[misc].append(Advice(
+            label=(
+                f"{{{{ Post Office|#post-office }}}}- Non Predatory Loot Box:"
+                f"<br>Up to +{round(nplb_dr_max_value, 2):g}% Drop Rate at {nplb['Max Level']} boxes invested"
+                f"<br>Non-maxed boxes: {nplb_unmaxed}"
+            ),
+            picture_class=nplb['Name'],
+            progression=nplb_lowest,
+            goal=nplb['Max Level']
+        ))
+    else:
+        drop_rate_pp_advice[misc].append(Advice(
+            label=f"{{{{ Post Office|#post-office }}}}- Non Predatory Loot Box:"
+                  f"<br>+{round(nplb_dr_max_value, 2):g}% Drop Rate",
+            picture_class=nplb['Name'],
+            progression=nplb_lowest,
+            goal=nplb['Max Level']
+        ))
+
+    # Prayers - Midas Minded
+    midas_minded_data = next(p for p in prayersDict.values() if p['Name'] == 'Midas Minded')
+    midas_minded_bonus_max = lavaFunc(
+        funcType=midas_minded_data['bonus_funcType'],
+        level=midas_minded_data['MaxLevel'],
+        x1=midas_minded_data['bonus_x1'],
+        x2=midas_minded_data['bonus_x2']
+    )
+    midas_minded_curse_max = lavaFunc(
+        funcType=midas_minded_data['curse_funcType'],
+        level=midas_minded_data['MaxLevel'],
+        x1=midas_minded_data['curse_x1'],
+        x2=midas_minded_data['curse_x2']
+    )
+
+    midas_minded_prayer = session_data.account.prayers['Midas Minded']
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"{{{{ Prayers|#prayers }}}}- Midas Minded:"
+              f"<br>+{round(midas_minded_prayer['BonusValue'], 2):g}/{round(midas_minded_bonus_max, 2):g}% Drop Rate Bonus | "
+              f"+{round(midas_minded_prayer['CurseValue'], 2):g}/{round(midas_minded_curse_max, 2):g}% Max HP for Monsters CURSE",
+        picture_class='midas-minded',
+        progression=midas_minded_prayer['Level'],
+        goal=midas_minded_data['MaxLevel']
+    ))
+
+    # Obols - Personal
+    best_obols = [None, 0]
+    for char in session_data.account.all_characters:
+        if best_obols[0] is None:
+            best_obols[0] = char.character_name
+        if char.obols.get('Total%_DROP_CHANCE', 0) > best_obols[1]:
+            best_obols[0] = char.character_name
+            best_obols[1] = char.obols.get('Total%_DROP_CHANCE', 0)
+    player_obol_drop_rate_max = obols_max_bonuses_dict['PlayerDropRateTrue']
+    drop_rate_pp_advice[misc].append(Advice(
+        label=f"Obols- Personal Obols:"
+              f"<br>+{best_obols[1]}/{player_obol_drop_rate_max}% Drop Rate on best ({best_obols[0]})"
+              f"<br>Note: Includes Rare and Hyper Obols, each rerolled with +1% DR",
+        picture_class='dementia-obol-of-infinisixes',
+        progression=best_obols[1],
+        goal=player_obol_drop_rate_max
+    ))
+
+    for subgroup in drop_rate_pp_advice:
+        for advice in drop_rate_pp_advice[subgroup]:
+            mark_advice_completed(advice)
+
+    drop_rate_ag = AdviceGroup(
+        tier="",
+        pre_string="Info- Player specific sources of Drop Rate",
+        post_string="Note: non-limited equipment that is worse than what you already have for the slot is excluded",
+        advices=drop_rate_pp_advice,
+        informational=True,
+    )
+    return drop_rate_ag
+
+def get_progression_tiers_advice_group() -> tuple[AdviceGroup, int, int, int]:
+    template_advice_dict = {
+        'Tiers': {},
+    }
+    info_tiers = 0
+    true_max = 0
+    max_tier = true_max - info_tiers
+    tier_DropRate = 0
+
+    #Assess Tiers
+    tiers_ag = AdviceGroup(
+        tier=tier_DropRate,
+        pre_string="Progression Tiers",
+        advices=template_advice_dict['Tiers']
+    )
+    overall_section_tier = min(true_max, tier_DropRate)
+    return tiers_ag, overall_section_tier, max_tier, true_max
+
+def get_drop_rate_advice_section() -> AdviceSection:
+    # Generate AdviceGroups
+    drop_rate_advice_group_dict = {}
+    drop_rate_advice_group_dict['Tiers'], overall_section_tier, max_tier, true_max = get_progression_tiers_advice_group()
+    drop_rate_advice_group_dict['Account'] = get_drop_rate_account_advice_group()
+    drop_rate_advice_group_dict['Player'] = get_drop_rate_player_advice_group()
+
+    # Generate AdviceSection
+    tier_section = f"{overall_section_tier}/{max_tier}"
+    drop_rate_advice_section = AdviceSection(
+        name="Drop Rate",
+        tier=tier_section,
+        pinchy_rating=overall_section_tier,
+        max_tier=max_tier,
+        true_max_tier=true_max,
+        header=f"Drop Rate Information",
+        picture='data/VaultUpg18.png',
+        groups=drop_rate_advice_group_dict.values(),
+        unrated=True,
+    )
+    return drop_rate_advice_section

--- a/mysite/general/pinchy.py
+++ b/mysite/general/pinchy.py
@@ -203,7 +203,7 @@ class Placements(dict):
         REFINERY:      [0,   0, 0, 0,    0,  0,  0,      1,  1,  1,      1,  1,  1,      1,  1,  1,      1,  1,  1,      1,     true_max_tiers[REFINERY], 99],
         SAMPLING:      [0,   0, 0, 0,    0,  1,  1,      1,  2,  2,      2,  3,  3,      3,  4,  5,      6,  7,  8,      10,    true_max_tiers[SAMPLING], 99],
         SALT_LICK:     [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  1,  2,      3,  4,  5,      6,  7,  8,      9,     true_max_tiers[SALT_LICK], 99],
-        DEATH_NOTE:    [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      3,  5,  5,      5,  5,  6,      10, 17, 24,     25,    true_max_tiers[DEATH_NOTE], 99],
+        DEATH_NOTE:    [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      3,  5,  5,      5,  5,  6,      10, 17, 22,     23,    true_max_tiers[DEATH_NOTE], 99],
         COLLIDER:      [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  0,  0,      0,  0,  0,      0,  0,  10,     13,    true_max_tiers[COLLIDER], 99],
         PRAYERS:       [0,   0, 0, 0,    0,  0,  0,      0,  1,  1,      2,  3,  4,      4,  5,  6,      7,  7,  7,      7,     true_max_tiers[PRAYERS], 99],
         TRAPPING:      [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      7,  7,  7,      7,  10, 10,     12, 12, 12,     12,    true_max_tiers[TRAPPING], 99],
@@ -351,7 +351,7 @@ def tier_from_monster_kills(dictOfPRs) -> Threshold:
     try:
         if dictOfPRs[Placements.SAMPLING][0] >= 10:
             expectedThreshold = Threshold.fromname(Threshold.MAX_TIER)
-        elif dictOfPRs[Placements.DEATH_NOTE][0] >= 24:
+        elif dictOfPRs[Placements.DEATH_NOTE][0] >= 22:
             expectedThreshold = Threshold.fromname(Threshold.W7_WAITING_ROOM)
         elif dictOfPRs[Placements.DEATH_NOTE][0] >= 17:
             expectedThreshold = Threshold.fromname(Threshold.SOLID_W7_PREP)

--- a/mysite/models/account_calcs.py
+++ b/mysite/models/account_calcs.py
@@ -1,13 +1,14 @@
+import copy
 from math import ceil, floor, log2, prod
 from consts import (
     # General
     lavaFunc, ceilUpToBase, ValueToMulti, getNextESFamilyBreakpoint,
-    base_crystal_chance,
+    base_crystal_chance, class_kill_talents_dict,
     filter_recipes, filter_never,
     # Master Classes
     grimoire_stack_types,
     # W1
-    vault_stack_types, grimoire_coded_stack_monster_order, decode_enemy_name,
+    vault_stack_types, grimoire_coded_stack_monster_order, decode_enemy_name, owl_bonuses_of_orion,
     # W2
     fishingToolkitDict,
     islands_trash_shop_costs,
@@ -38,6 +39,7 @@ def calculate_account(account):
     _calculate_wave_3(account)
 
 def _calculate_wave_1(account):
+    # These numbers are used by formulas in _calculate_wave_2, so must be calculated first
     _calculate_caverns_majiks(account)
     _calculate_w6_summoning_winner_bonuses(account)
     _calculate_w2_arcade(account)
@@ -109,7 +111,8 @@ def _calculate_caverns_majiks(account):
                         majik_data['BonusPerLevel'] ** majik_data['MaxLevel']
                     )
             account.caverns['Majiks'][majik_data['Name']]['Description'] = (
-                f"{account.caverns['Majiks'][majik_data['Name']]['Value']}/{account.caverns['Majiks'][majik_data['Name']]['MaxValue']}"
+                f"{round(account.caverns['Majiks'][majik_data['Name']]['Value'], 2):g}"
+                f"/{round(account.caverns['Majiks'][majik_data['Name']]['MaxValue'], 2):g}"
                 f"{account.caverns['Majiks'][majik_data['Name']]['Description']}"
             )
             # logger.debug(f"{majik_data['Name']} value set to {account.caverns['Majiks'][majik_data['Name']]['Value']}")
@@ -232,6 +235,7 @@ def _calculate_w2_arcade(account):
         account.arcade[upgrade_index]['Display'] = (
             f"+{account.arcade[upgrade_index]['Value']:.2f}{upgrade_details['Display Type']} {upgrade_details['Stat']}"
         )
+
 
 def _calculate_wave_2(account):
     _calculate_general(account)
@@ -489,6 +493,7 @@ def _calculate_w1(account):
     _calculate_w1_starsigns(account)
     _calculate_w1_statues(account)
     _calculate_w1_stamps(account)
+    _calculate_w1_owl_bonuses(account)
 
 def _calculate_w1_upgrade_vault(account):
     vault_multi = [
@@ -611,13 +616,50 @@ def _calculate_w1_stamps(account):
         + account.compass['Upgrades']['Abomination Slayer XVII']['Total Value']
     )
 
-    for stamp_name in account.stamps:
-        if account.stamps[stamp_name]['Exalted']:
-            try:
-                account.stamps[stamp_name]['Value'] *= account.exalted_stamp_multi
-            except:
-                logger.exception(f"Failed to upgrade the Value of {stamp_name}")
-                continue
+    for stamp_name, stamp_values in account.stamps.items():
+        try:
+            account.stamps[stamp_name]['Total Value'] = (
+                stamp_values['Value']
+                * (2 if account.labBonuses['Certified Stamp Book']['Enabled'] and stamp_values['StampType'] != 'Misc' else 1)
+                * (1.25 if account.sneaking['PristineCharms']['Liqorice Rolle']['Obtained'] and stamp_values['StampType'] != 'Misc' else 1)
+                * (account.exalted_stamp_multi if stamp_values['Exalted'] else 1)
+            )
+        except:
+            account.stamps[stamp_name]['Total Value'] = stamp_values['Value']
+            logger.exception(f"Failed to calculate the Total Value of {stamp_name}")
+            continue
+
+
+
+def _calculate_w1_owl_bonuses(account):
+    bonuses_of_orion_num = len(owl_bonuses_of_orion)
+    bonuses_of_orion_owned = account.owl['BonusesOfOrion']
+    megafeathers_owned = account.owl['MegaFeathersOwned']
+    megafeather_mod = 0
+    if megafeathers_owned >= 10:
+        megafeather_mod = 6 + ((megafeathers_owned - 10) * 0.5)
+    elif megafeathers_owned > 7:
+        megafeather_mod = 5
+    elif megafeathers_owned > 5:
+        megafeather_mod = 4
+    elif megafeathers_owned > 3:
+        megafeather_mod = 3
+    elif megafeathers_owned > 1:
+        megafeather_mod = 2
+
+    account.owl['Bonuses'] = {}
+    for bonus_index, (bonus_name, bonus) in enumerate(owl_bonuses_of_orion.items()):
+        bonus_base = bonus['BaseValue']
+        if account.owl['Discovered']:
+            bonus_num_unlocked = (floor(bonuses_of_orion_owned/bonuses_of_orion_num) + (1 if (bonuses_of_orion_owned % bonuses_of_orion_num) > bonus_index else 0))
+        else:
+            bonus_num_unlocked = 0
+        bonus_value = bonus_base * bonus_num_unlocked * megafeather_mod
+        account.owl['Bonuses'][bonus_name] = {
+            'BaseValue': bonus_base,
+            'NumUnlocked': bonus_num_unlocked,
+            'Value': safer_convert(bonus_value, 0)
+    }
 
 def _calculate_w2(account):
     _calculate_w2_vials(account)
@@ -885,6 +927,7 @@ def _calculate_w4(account):
     _calculate_w4_jewel_multi(account)
     _calculate_w4_meal_multi(account)
     _calculate_w4_lab_bonuses(account)
+    _calculate_w4_tome_bonuses(account)
 
 def _calculate_w4_cooking_max_plate_levels(account):
     # Sailing Artifact Increases
@@ -985,7 +1028,6 @@ def _calculate_w4_meal_multi(account):
         else:
             account.meals[meal]['Description'] = account.meals[meal]['Effect']
 
-
 def _calculate_w4_lab_bonuses(account):
     account.labBonuses['No Bubble Left Behind']['Value'] = 3
 
@@ -1000,6 +1042,29 @@ def _calculate_w4_lab_bonuses(account):
     account.labBonuses['No Bubble Left Behind']['Value'] *= account.labBonuses['No Bubble Left Behind']['Enabled']
     #Now for the bullshit: Lava has a hidden cap of 10 bubbles
     account.labBonuses['No Bubble Left Behind']['Value'] = min(nblbMaxBubbleCount, account.labBonuses['No Bubble Left Behind']['Value'])
+
+def _calculate_w4_tome_bonuses(account):
+    # DMG
+
+    # Skill Efficiency
+
+    # Drop Rarity
+    account.tome['Bonuses']['Drop Rarity']['Value'] = (
+        account.tome['Red Pages Unlocked']  #Sets the whole value to 0 if player hasn't turned in Red Pages yet
+        * 2
+        * safer_math_pow(
+            floor(
+                max(0, account.tome['Total Points'] - 8000)
+                / 100
+            ),
+            0.7
+        )
+    )
+    account.tome['Bonuses']['Drop Rarity']['Total Value'] = (
+        account.tome['Bonuses']['Drop Rarity']['Value']
+        * ValueToMulti(account.grimoire['Upgrades']['Grey Tome Book']['Level'])
+    )
+    # logger.debug(f"{account.tome['Total Points']} Tome points = +{account.tome['Bonuses']['Drop Rarity']['Value']}% Drop Rate")
 
 def _calculate_w5(account):
     account.divinity['AccountWideArctis'] = account.companions['King Doot'] or 'Arctis' in account.caverns['PocketDivinityLinks']
@@ -1086,8 +1151,12 @@ def _calculate_caverns_measurements_multis(account):
                 'PrettyRaw': f"{sum_combat_levels:,}",
                 'Prepped': sum_combat_levels / 500  # In the source code, this is when 99 = i
             }
-        # elif entry_index == 3:  #Tome Score
-        #     pass
+        elif entry_index == 3:  #Tome Score
+            account.caverns['MeasurementMultis'][clean_entry_name] = {
+                'Raw': account.tome['Total Points'],
+                'PrettyRaw': f"{account.tome['Total Points']:,}",
+                'Prepped': account.tome['Total Points'] / 2500  # In the source code, this is when 99 = i
+            }
         elif entry_index == 4:  #All Skill Lv
             total_skill_levels = 0
             for skill, skill_levels in account.all_skills.items():
@@ -1540,7 +1609,7 @@ def _calculate_caverns_gambit(account):
         _update_w3_building_max_levels(account, 'All Towers', 100, 'Gambit Cavern upgrade Index 9')
 
 def _calculate_w6(account):
-    _calculate_w6_farming(account)
+    # _calculate_w6_farming(account)  # Runs in wave3 due to Land Rank multi from Talents
     _calculate_w6_summoning(account)
 
 def _calculate_w6_sneaking_gemstones(account):
@@ -1562,6 +1631,8 @@ def _calculate_w6_sneaking_gemstones(account):
                 account.sneaking['Gemstones'][gemstone_name]['BoostedValue'] = account.sneaking['Gemstones'][gemstone_name]['BaseValue']
 
 def _calculate_w6_farming(account):
+    # Runs in wave3 due to Land Rank multi from Talents
+    _calculate_w6_farming_land_ranks(account)
     _calculate_w6_farming_crop_depot(account)
     _calculate_w6_farming_markets(account)
     _calculate_w6_farming_crop_value(account)
@@ -1569,6 +1640,35 @@ def _calculate_w6_farming(account):
     _calculate_w6_farming_crop_speed(account)
     _calculate_w6_farming_bean_bonus(account)
     _calculate_w6_farming_og(account)
+
+def _calculate_w6_farming_land_ranks(account):
+    highest_dank_rank_level = 0
+    for db in account.dbs:
+        highest_dank_rank_level = max(
+            highest_dank_rank_level,
+            db.current_preset_talents.get('207', 0) + db.total_bonus_talent_levels,
+            db.secondary_preset_talents.get('207', 0) + db.total_bonus_talent_levels
+        )
+
+    dank_rank_multi = max(1, lavaFunc(
+        funcType=all_talentsDict[207]['funcX'],
+        level=highest_dank_rank_level,
+        x1=all_talentsDict[207]['x1'],
+        x2=all_talentsDict[207]['x2'],
+    ))
+
+    for upgrade_name, upgrade_details in account.farming['LandRankDatabase'].items():
+        if upgrade_details['Index'] % 5 != 4:
+            account.farming['LandRankDatabase'][upgrade_name]['Value'] = (
+                dank_rank_multi
+                * ((1.7 * upgrade_details['BaseValue'] * upgrade_details['Level']) / (upgrade_details['Level'] + 80))
+            )
+        else:
+            account.farming['LandRankDatabase'][upgrade_name]['Value'] = (
+                dank_rank_multi
+                * upgrade_details['BaseValue']
+                * upgrade_details['Level']
+            )
 
 def _calculate_w6_farming_crop_depot(account):
     lab_multi = ValueToMulti(
@@ -1673,12 +1773,7 @@ def _calculate_w6_farming_crop_evo(account):
         * ValueToMulti(account.farming['Evo']['Vial Value'])
     )
     # Stamp
-    account.farming['Evo']['Stamp Value'] = (
-            max(1, 2 * account.labBonuses['Certified Stamp Book']['Enabled'])
-            * max(1, 1.25 * account.sneaking['PristineCharms']['Liqorice Rolle']['Obtained'])
-            * account.stamps['Crop Evo Stamp']['Value']
-    )
-    account.farming['Evo']['Stamp Multi'] = ValueToMulti(account.farming['Evo']['Stamp Value'])
+    account.farming['Evo']['Stamp Multi'] = ValueToMulti(account.stamps['Crop Evo Stamp']['Total Value'])
     # Meals
     account.farming['Evo']['Nyan Stacks'] = ceil((max(account.all_skills['Summoning'], default=0) + 1) / 50)
     account.farming['Evo']['Meals Multi'] = (
@@ -1823,6 +1918,8 @@ def _calculate_wave_3(account):
     _calculate_general_crystal_spawn_chance(account)
     _calculate_w6_sneaking_gemstones(account)
     _calculate_master_classes_grimoire_bone_sources(account)
+    _calculate_class_unique_kill_stacks(account)
+    _calculate_w6_farming(account)
 
 def _calculate_w3_library_max_book_levels(account):
     account.library['StaticSum'] = (
@@ -1900,6 +1997,15 @@ def _calculate_general_character_over_books(account):
             "Progression": account.sneaking['MaxMastery'],
             "Goal": 3
         },
+        'Grimoire': {
+            'Value': account.grimoire['Upgrades']['Skull of Major Talent']['Level'],
+            'Image': account.grimoire['Upgrades']['Skull of Major Talent']['Image'],
+            'Label': f"{{{{Grimoire |  #the-grimoire}}}}: Skull of Major Talent: "
+                     f"+{account.grimoire['Upgrades']['Skull of Major Talent']['Level']}"
+                     f"/{account.grimoire['Upgrades']['Skull of Major Talent']['Max Level']}",
+            'Progression': account.grimoire['Upgrades']['Skull of Major Talent']['Level'],
+            'Goal': account.grimoire['Upgrades']['Skull of Major Talent']['Max Level']
+        }
     }
     account.bonus_talents_account_wide_sum = 0
     for bonusName, bonusValuesDict in account.bonus_talents.items():
@@ -2002,3 +2108,44 @@ def _calculate_general_crystal_spawn_chance(account):
     account.highest_jman_crystal_spawn_chance = max(
         [char.crystal_spawn_chance for char in account.all_characters if "Journeyman" in char.all_classes], default=base_crystal_chance
     )
+
+def _calculate_class_unique_kill_stacks(account):
+    abc = {
+        'King of the Remembered': {
+            'Talent Number': 178,
+            'Class List': account.dks,
+            'Bonus': 'Printer Output',
+        },
+        'Archlord of the Pirates': {
+            'Talent Number': 328,
+            'Class List': account.sbs,
+            'Bonus': 'Drop Rate and Class EXP',
+        },
+        'Wormhole Emperor': {
+            'Talent Number': 508,
+            'Class List': account.sorcs,
+            'Bonus': 'Damage',
+        }
+    }
+    for talent_name, talent_details in abc.items():
+        talent_levels = []
+        for char in talent_details['Class List']:
+            talent_levels.append(char.current_preset_talents.get(f"{talent_details['Talent Number']}", 0) + char.total_bonus_talent_levels)
+            talent_levels.append(char.secondary_preset_talents.get(f"{talent_details['Talent Number']}", 0) + char.total_bonus_talent_levels)
+
+        account.class_kill_talents[talent_name]['Bonus Type'] = abc[talent_name]['Bonus']
+        account.class_kill_talents[talent_name]['funcType'] = all_talentsDict[talent_details['Talent Number']]['funcX']
+        account.class_kill_talents[talent_name]['x1'] = all_talentsDict[talent_details['Talent Number']]['x1']
+        account.class_kill_talents[talent_name]['x2'] = all_talentsDict[talent_details['Talent Number']]['x2']
+        account.class_kill_talents[talent_name]['Highest Preset Level'] = max(talent_levels, default=0)
+        account.class_kill_talents[talent_name]['Talent Value'] = lavaFunc(
+            funcType=account.class_kill_talents[talent_name]['funcType'],
+            level=account.class_kill_talents[talent_name]['Highest Preset Level'],
+            x1=account.class_kill_talents[talent_name]['x1'],
+            x2=account.class_kill_talents[talent_name]['x2']
+        )
+        account.class_kill_talents[talent_name]['Kill Stacks'] = safer_math_log(account.class_kill_talents[talent_name]['Kills'], 'Lava')
+        account.class_kill_talents[talent_name]['Total Value'] = (
+            account.class_kill_talents[talent_name]['Talent Value'] * account.class_kill_talents[talent_name]['Kill Stacks']
+        )
+        # logger.debug(f"{account.class_kill_talents[talent_name] = }")

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -9,7 +9,7 @@ from consts import (
     gfood_codes,
     card_raw_data, cardset_names, decode_enemy_name,
     gemShopDict, gem_shop_optlacc_dict, gem_shop_bundles_dict,
-    guildBonusesList, familyBonusesDict, achievementsList, allMeritsDict, starsignsDict,
+    guild_bonuses_dict, familyBonusesDict, achievementsList, allMeritsDict, starsignsDict,
     event_points_shop_dict,
     npc_tokens,
     companions,
@@ -27,7 +27,7 @@ from consts import (
     sigilsDict,
     arcadeBonuses, arcade_max_level,
     ballotDict,
-    obolsDict, ignorable_obols_list,
+    obols_dict, ignorable_obols_list,
     islands_dict, killroy_dict,
     # W3
     refineryDict, buildingsDict, saltLickList, atomsList, colliderStorageLimitList, buildings_shrines, prayersDict,
@@ -56,7 +56,7 @@ from consts import (
     caverns_gambit_pts_bonuses, caverns_gambit_challenge_names, caverns_gambit_total_challenges, schematics_unlocking_gambit_challenges,
 )
 from models.models import Character, buildMaps, EnemyWorld, Card, Assets
-from utils.data_formatting import getCharacterDetails, safe_loads, safer_get, safer_convert
+from utils.data_formatting import getCharacterDetails, safe_loads, safer_get, safer_convert, get_obol_totals
 from utils.logging import get_logger
 from utils.text_formatting import getItemDisplayName, numberToLetter
 
@@ -138,7 +138,7 @@ def _all_stored_items(account) -> Assets:
 def _all_worn_items(account) -> Assets:
     stuff_worn = defaultdict(int)
     for toon in account.safe_characters:
-        for item in [*toon.equipment.foods, *toon.equipment.equips]:
+        for item in [*toon.equipment.foods, *toon.equipment.equips, *toon.equipment.tools]:
             if item.codename == 'Blank':
                 continue
             stuff_worn[item.codename] += item.amount
@@ -233,7 +233,6 @@ def _parse_characters(account, run_type):
     _parse_character_class_lists(account)
 
 def _parse_character_class_lists(account):
-
     account.beginners = [toon for toon in account.all_characters if 'Beginner' in toon.all_classes or 'Journeyman' in toon.all_classes]
     account.jmans = [toon for toon in account.all_characters if 'Journeyman' in toon.all_classes]
     account.maestros = [toon for toon in account.all_characters if 'Maestro' in toon.all_classes]
@@ -246,8 +245,10 @@ def _parse_character_class_lists(account):
 
     account.mages = [toon for toon in account.all_characters if 'Mage' in toon.all_classes]
     account.bubos = [toon for toon in account.all_characters if 'Bubonic Conjuror' in toon.all_classes]
+    account.sorcs = [toon for toon in account.all_characters if 'Elemental Sorcerer' in toon.all_classes]
 
     account.wws = [toon for toon in account.all_characters if 'Wind Walker' in toon.all_classes]
+    account.sbs = [toon for toon in account.all_characters if 'Siege Breaker' in toon.all_classes]
 
 def _parse_general(account):
     # General / Multiple uses
@@ -319,7 +320,6 @@ def _parse_general_gem_shop_bundles(account):
     if unknown_bundles:
         logger.warning(f"Unknown Gem Shop Bundles found: {unknown_bundles}")
 
-
 def _parse_general_quests(account):
     account.compiled_quests = {}
     for charIndex, questsDict in enumerate(account.all_quests):
@@ -355,9 +355,17 @@ def _parse_general_npc_tokens(account):
     #     account.all_assets.get(tokenName).add(tokenCount)
 
 def _parse_class_unique_kill_stacks(account):
-    account.dk_orb_kills = safer_get(account.raw_optlacc_dict, 138, 0)
-    account.sb_plunder_kills = safer_get(account.raw_optlacc_dict, 139, 0)
-    account.es_wormhole_kills = safer_get(account.raw_optlacc_dict, 152, 0)
+    account.class_kill_talents = {
+        'Archlord of the Pirates': {
+            'Kills': safer_get(account.raw_optlacc_dict, 139, 0),
+        },
+        'King of the Remembered': {
+            'Kills': safer_get(account.raw_optlacc_dict, 138, 0),
+        },
+        'Wormhole Emperor': {
+            'Kills': safer_get(account.raw_optlacc_dict, 152, 0),
+        }
+    }
 
 def _parse_family_bonuses(account):
     account.family_bonuses = {}
@@ -466,14 +474,21 @@ def _parse_general_merits(account):
                 continue  # Already defaulted to 0 in Consts
 
 def _parse_general_guild_bonuses(account):
-    account.guildBonuses = {}
+    account.guild_bonuses = {}
     raw_guild = safe_loads(account.raw_data.get('Guild', [[]]))
-    for bonusIndex, bonusName in enumerate(guildBonusesList):
+    for bonus_index, (bonus_name, bonus) in enumerate(guild_bonuses_dict.items()):
         try:
-            account.guildBonuses[bonusName] = safer_convert(raw_guild[0][bonusIndex], 0)
+            guild_bonus_level = safer_convert(raw_guild[0][bonus_index], 0)
         except Exception as e:
             logger.warning(f"Guild Bonus Parse error: {e}. Defaulting to 0")
-            account.guildBonuses[bonusName] = 0
+            guild_bonus_level = 0
+        account.guild_bonuses[bonus_name] = {
+            'Level': guild_bonus_level,
+            'Value': lavaFunc(bonus['funcType'], guild_bonus_level, bonus['x1'], bonus['x2']),
+            'Max Level': bonus['Max Level'],
+            'Max Value': bonus['Max Value'],
+            'Image': bonus['Image']
+        }
 
 def _parse_general_printer(account):
     account.printer = {
@@ -1192,10 +1207,10 @@ def _parse_w2_cauldrons(account):
         ]
     except Exception as e:
         logger.warning(f"Alchemy bubble cauldron Boosts Parse error: {e}. Defaulting to 0s")
-        account.alchemy_cauldrons["OrangeBoosts"]: [0, 0, 0, 0]
-        account.alchemy_cauldrons["GreenBoosts"]: [0, 0, 0, 0]
-        account.alchemy_cauldrons["PurpleBoosts"]: [0, 0, 0, 0]
-        account.alchemy_cauldrons["YellowBoosts"]: [0, 0, 0, 0]
+        account.alchemy_cauldrons["OrangeBoosts"] = [0, 0, 0, 0]
+        account.alchemy_cauldrons["GreenBoosts"] = [0, 0, 0, 0]
+        account.alchemy_cauldrons["PurpleBoosts"] = [0, 0, 0, 0]
+        account.alchemy_cauldrons["YellowBoosts"] = [0, 0, 0, 0]
     try:
         account.alchemy_cauldrons["WaterDroplets"] = [safer_convert(raw_cauldron_upgrades[18], 0), safer_convert(raw_cauldron_upgrades[19], 0)]
         account.alchemy_cauldrons["LiquidNitrogen"] = [safer_convert(raw_cauldron_upgrades[22], 0), safer_convert(raw_cauldron_upgrades[23], 0)]
@@ -1409,8 +1424,8 @@ def _parse_w2_obols(account):
     }
     raw_owned_obols = []
     for jsonkey in [
-        "ObolEqO1", "ObolEqO2", "ObolEqO0_0", "ObolEqO0_1", "ObolEqO0_2", "ObolEqO0_3", "ObolEqO0_4",
-        "ObolEqO0_5", "ObolEqO0_6", "ObolEqO0_7", "ObolEqO0_8", "ObolEqO0_9"
+        'ObolEqO1', 'ObolEqO2', 'ObolEqO0_0', 'ObolEqO0_1', 'ObolEqO0_2', 'ObolEqO0_3', 'ObolEqO0_4',
+        'ObolEqO0_5', 'ObolEqO0_6', 'ObolEqO0_7', 'ObolEqO0_8', 'ObolEqO0_9'
     ]:
         raw_owned_obols += safe_loads(account.raw_data.get(jsonkey, []))
     raw_obol_inventory_list = safe_loads(account.raw_data.get("ObolInvOr"))
@@ -1418,13 +1433,17 @@ def _parse_w2_obols(account):
         raw_owned_obols += subdict.values()
     for obol in raw_owned_obols:
         if obol not in ignorable_obols_list:
-            obolBonusType = obolsDict.get(obol, {}).get('Bonus', 'Unknown')
-            obolShape = obolsDict.get(obol, {}).get('Shape', 'Unknown')
+            obolBonusType = obols_dict.get(obol, {}).get('Bonus', 'Unknown')
+            obolShape = obols_dict.get(obol, {}).get('Shape', 'Unknown')
             account.obols[obolBonusType][obolShape]['Total'] += 1
             if obol not in account.obols[obolBonusType][obolShape]:
                 account.obols[obolBonusType][obolShape][obol] = {'Count': 1}
             else:
                 account.obols[obolBonusType][obolShape][obol]['Count'] += 1
+    
+    raw_family_obols_list = safe_loads(account.raw_data.get('ObolEqO1'))
+    raw_family_obols_upgrades = safe_loads(account.raw_data.get('ObolEqMAPz1'))
+    account.obols['BonusTotals'] = get_obol_totals(raw_family_obols_list, raw_family_obols_upgrades)
 
 def _parse_w2_islands(account):
     account.islands = {
@@ -1840,6 +1859,7 @@ def _parse_w4(account):
     _parse_w4_lab(account)
     _parse_w4_rift(account)
     _parse_w4_breeding(account)
+    _parse_w4_tome(account)
 
 def _parse_w4_cooking(account):
     account.cooking = {
@@ -1912,6 +1932,20 @@ def _parse_w4_cooking_ribbons(account):
             account.meals[meal_name]['RibbonTier'] = 0
             if raw_ribbons:
                 logger.exception(f"Could not retrieve Ribbon for {meal_name}")
+
+def _parse_w4_tome(account):
+    account.tome = {
+        'Data Present': 'totalTomePoints' in account.raw_data.get('parsedData', {}),
+        'Total Points': floor(account.raw_data.get('parsedData', {}).get('totalTomePoints', 0)),
+        'Blue Pages Unlocked': safer_convert(safer_get(account.raw_optlacc_dict, 196, False), False),
+        'Red Pages Unlocked': safer_convert(safer_get(account.raw_optlacc_dict, 197, False), False),
+        'Bonuses': {
+            'DMG': {},
+            'Skill Efficiency': {},
+            'Drop Rarity': {},
+        }
+    }
+
 
 def _parse_w4_lab(account):
     raw_lab = safe_loads(account.raw_data.get("Lab", []))
@@ -3396,17 +3430,15 @@ def _parse_w6_farming_land_ranks(account, rawRanks):
             account.farming['LandRankDatabase'][upgradeValuesDict['Name']] = {
                 'Level': rawRanks[2][upgradeIndex],
                 'BaseValue': upgradeValuesDict['Value'],
-                'Value': (
-                    (1.7 * upgradeValuesDict['Value'] * rawRanks[2][upgradeIndex]) / (rawRanks[2][upgradeIndex] + 80)
-                    if upgradeIndex not in [4, 9, 14, 19]
-                    else upgradeValuesDict['Value'] * rawRanks[2][upgradeIndex]
-                )
+                'Value': 0,  #Updated in account_calcs._calculate_w6_farming_land_ranks()
+                'Index': upgradeIndex
             }
         except:
             account.farming['LandRankDatabase'][upgradeValuesDict['Name']] = {
                 'Level': 0,
                 'BaseValue': upgradeValuesDict['Value'],
-                'Value': 0
+                'Value': 0,
+                'Index': upgradeIndex
             }
 
 def _parse_w6_summoning(account):

--- a/mysite/requirements/dev.txt
+++ b/mysite/requirements/dev.txt
@@ -1,2 +1,3 @@
 -r common.txt
 coloredlogs
+dotenv

--- a/mysite/static/assets/_cards.scss
+++ b/mysite/static/assets/_cards.scss
@@ -237,7 +237,7 @@ $bosses-n-nightmares: (
 	kattlekruk-card: img('wiki/Kattlekruk_Card.png'),
 	chaotic-kattlekruk-card: img('wiki/Chaotic_Kattlekruk_Card.png'),
 	sacrilegious-kattlekruk-card: img('wiki/Sacrilegious_Kattlekruk_Card.png'),
-    demented-spiritlord-card: img('wiki/Demented_Spiritlord_Card.png'),
+	demented-spiritlord-card: img('wiki/Demented_Spiritlord_Card.png'),
 	emperor-card: img('wiki/Emperor_Card.png'),
 	chaotic-emperor-card: img('wiki/Chaotic_Emperor_Card.png'),
 	sovereign-emperor-card: img('wiki/Sovereign_Emperor_Card.png')

--- a/mysite/static/assets/_guild.scss
+++ b/mysite/static/assets/_guild.scss
@@ -1,0 +1,20 @@
+$guild-bonus-map: (
+    guild-gifts: img('wiki/Guild_Gifts.png'),
+    stat-runes: img('wiki/Stat_Runes.png'),
+    rucksack: img('wiki/Rucksack.png'),
+    power-of-pow: img('wiki/Power_of_Pow'),
+    rem-fighting: img('wikiREM_Fighting'),
+    make-or-break: img('wiki/Make_or_Break.png'),
+    multi-tool: img('wiki/Multi_Tool.png'),
+    skilley-skiller: img('wiki/Skilley_Skiller.png'),
+    coin-supercharger: img('wiki/Coin_Supercharger.png'),
+    bonus-gp-for-small-guilds: img('wiki/Bonus_GP_for_small_guilds.png'),
+    gold-charm: img('wiki/Gold_Charm.png'),
+    star-dazzle: img('wiki/Star_Dazzle.png'),
+    c2-card-spotter: img('wiki/C2_Card_Spotter.png'),
+    bestone: img('wiki/Bestone.png'),
+    sleepy-skillet: img('wiki/Sleepy_Skillet.png'),
+    craps: img('wiki/Craps.png'),
+    anotha-one: img('wiki/Anotha_One.png'),
+    wait-a-minute: img('wiki/Wait_A_Minute.png')
+);

--- a/mysite/static/assets/image-mapping.scss
+++ b/mysite/static/assets/image-mapping.scss
@@ -8,8 +8,6 @@
 @import "skill-icons";
 @import "classes";
 @import "talents";
-@import "grimoire";
-@import "compass";
 @import "gem-shop";
 @import "storage-items";
 @import "boss-keys";
@@ -20,11 +18,40 @@
 @import "companions";
 @import "ui";
 @import "event-shop";
+@import "guild";
+
+$id-map: map-merge($all-world-contents, $all-slab);
+$id-map: map-merge($id-map, $sections-map);
+$id-map: map-merge($id-map, $skill-icons);
+$id-map: map-merge($id-map, $character-classes);
+$id-map: map-merge($id-map, $talents);
+$id-map: map-merge($id-map, $gem-shop);
+$id-map: map-merge($id-map, $all-storage-items);
+$id-map: map-merge($id-map, $boss-keys);
+$id-map: map-merge($id-map, $starsigns);
+$id-map: map-merge($id-map, $all-cards);
+$id-map: map-merge($id-map, $achievements);
+$id-map: map-merge($id-map, $merits);
+$id-map: map-merge($id-map, $companions-map);
+$id-map: map-merge($id-map, $ui-map);
+$id-map: map-merge($id-map, $event-shop);
+$id-map: map-merge($id-map, $guild-bonus-map);
+
+//Master Classes
+@import "grimoire";
+@import "compass";
+
+$id-map: map-merge($id-map, $all-grimoire);
+$id-map: map-merge($id-map, $all-compass);
 
 //W1
 @import "upgrade_vault";
 @import "bribes";
 @import "owl";
+
+$id-map: map-merge($id-map, $all-vault);
+$id-map: map-merge($id-map, $bribes-map);
+$id-map: map-merge($id-map, $owl-map);
 
 //W2
 @import "alchemy";
@@ -36,10 +63,23 @@
 @import "islands";
 @import "weekly_bosses";
 
+$id-map: map-merge($id-map, $all-alchemy);
+$id-map: map-merge($id-map, $arcade);
+$id-map: map-merge($id-map, $postoffice);
+$id-map: map-merge($id-map, $kangaroo-map);
+$id-map: map-merge($id-map, $ballot);
+$id-map: map-merge($id-map, $all-islands);
+$id-map: map-merge($id-map, $all-killroy);
+$id-map: map-merge($id-map, $all-weekly-boss-map);
+
 //W3
 @import "construction";
 @import "worship";
 @import "equinox";
+
+$id-map: map-merge($id-map, $all-construction);
+$id-map: map-merge($id-map, $all-worship);
+$id-map: map-merge($id-map, $equinox);
 
 //W4
 @import "breeding";
@@ -47,61 +87,30 @@
 @import "meals";
 @import "laboratory";
 
+$id-map: map-merge($id-map, $breeding-map);
+$id-map: map-merge($id-map, $rift);
+$id-map: map-merge($id-map, $all-cooking);
+$id-map: map-merge($id-map, $all-laboratory);
+
 //W5
-@import "slab-items";
 @import "divinity";
 @import "sailing";
 @import "gaming";
 @import "caverns";
+
+$id-map: map-merge($id-map, $divinity-map);
+$id-map: map-merge($id-map, $all-sailing);
+$id-map: map-merge($id-map, $all-gaming);
+$id-map: map-merge($id-map, $all-caverns);
 
 //W6
 @import "sneaking";
 @import "farming";
 @import "summoning";
 
-$id-map: map-merge($all-world-contents, $all-slab);
-$id-map: map-merge($sections-map, $id-map);
-$id-map: map-merge($skill-icons, $id-map);
-$id-map: map-merge($all-storage-items, $id-map);
-$id-map: map-merge($character-classes, $id-map);
-$id-map: map-merge($breeding-map, $id-map);
-$id-map: map-merge($bribes-map, $id-map);
-$id-map: map-merge($boss-keys, $id-map);
-$id-map: map-merge($all-cards, $id-map);
-$id-map: map-merge($rift, $id-map);
-$id-map: map-merge($equinox, $id-map);
-$id-map: map-merge($all-cooking, $id-map);
-$id-map: map-merge($talents, $id-map);
-$id-map: map-merge($divinity-map, $id-map);
-$id-map: map-merge($all-sailing, $id-map);
-$id-map: map-merge($all-laboratory, $id-map);
-$id-map: map-merge($all-sneaking, $id-map);
-$id-map: map-merge($starsigns, $id-map);
-$id-map: map-merge($all-alchemy, $id-map);
-$id-map: map-merge($achievements, $id-map);
-$id-map: map-merge($arcade, $id-map);
-$id-map: map-merge($all-construction, $id-map);
-$id-map: map-merge($all-worship, $id-map);
-$id-map: map-merge($gem-shop, $id-map);
-$id-map: map-merge($merits, $id-map);
-$id-map: map-merge($postoffice, $id-map);
-$id-map: map-merge($owl-map, $id-map);
-$id-map: map-merge($companions-map, $id-map);
-$id-map: map-merge($all-gaming, $id-map);
-$id-map: map-merge($kangaroo-map, $id-map);
-$id-map: map-merge($all-farming, $id-map);
-$id-map: map-merge($all-summoning, $id-map);
-$id-map: map-merge($ballot, $id-map);
-$id-map: map-merge($ui-map, $id-map);
-$id-map: map-merge($all-islands, $id-map);
-$id-map: map-merge($all-killroy, $id-map);
-$id-map: map-merge($all-weekly-boss-map, $id-map);
-$id-map: map-merge($all-caverns, $id-map);
-$id-map: map-merge($event-shop, $id-map);
-$id-map: map-merge($all-grimoire, $id-map);
-$id-map: map-merge($all-vault, $id-map);
-$id-map: map-merge($all-compass, $id-map);
-
+$id-map: map-merge($id-map, $all-sneaking);
+$id-map: map-merge($id-map, $all-farming);
+$id-map: map-merge($id-map, $all-summoning);
 
 
 @each $class, $link in $id-map {

--- a/mysite/static/enemy-maps.json
+++ b/mysite/static/enemy-maps.json
@@ -17,7 +17,7 @@
     ["Rats Nest", 15, "Rats", 35000, "Basic W1 Enemies", "Basic W1 Enemies", "Basic W1 Enemies", "Basic W1 Enemies", "Rat"],
     ["The Roots", 30, "TD Nutto", 0, "Easy Extras", "Easy Extras", "Medium Extras", "Medium Extras", "Nutto"],
     ["The Office", 9, "Dr. Def Poops", 0, "Easy Extras", "Easy Extras", "Easy Extras", "Easy Extras", "Poop"],
-    ["Meel's Crypt", 38, "Boops", 0, "Easy Extras", "Difficult Extras", "Impossible", "Impossible", "Boop"],
+    ["Meel's Crypt", 38, "Boops", 0, "Easy Extras", "Difficult Extras", "Insane", "Impossible", "Boop"],
 
     ["Jar Bridge", 51, "Sandy Pot", 250, "Basic W2 Enemies", "Basic W2 Enemies", "Basic W2 Enemies", "Basic W2 Enemies", "Sandy-Pot"],
     ["The Mimic Hole", 52, "Mimic", 600, "Basic W2 Enemies", "Basic W2 Enemies", "Basic W2 Enemies", "Basic W2 Enemies", "Mimic"],

--- a/mysite/taskSuggester.py
+++ b/mysite/taskSuggester.py
@@ -12,7 +12,7 @@ from models.models import AdviceWorld, WorldName, Account
 from utils.data_formatting import getJSONfromAPI, getJSONfromText, HeaderData, safer_convert
 from utils.logging import get_logger
 from utils.text_formatting import is_username
-from general import combatLevels, greenstacks, pinchy, cards, secretPath, consumables, gemShop, active, achievements, eventShop
+from general import combatLevels, greenstacks, pinchy, cards, secretPath, consumables, gemShop, active, achievements, eventShop, drop_rate
 from master_classes import grimoire, compass
 from w1 import upgrade_vault, stamps, bribes, smithing, statues, starsigns, owl
 from w2 import alchemy, post_office, killroy, islands, arcade, bonus_ballot
@@ -75,6 +75,7 @@ def main(inputData, source_string, runType="web"):
             combatLevels.getCombatLevelsAdviceSection(),
             secretPath.getSecretClassAdviceSection(),
             active.getActiveAdviceSection(),
+            drop_rate.get_drop_rate_advice_section(),
             achievements.getAchievementsAdviceSection(),
             *(consumables.getConsumablesAdviceSections()),
             gemShop.getGemShopAdviceSection(),

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,7 +7,7 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-05-12: New section coming soon: Drop Rate
+        Beta testing: 2025-05-16: New section: General > Drop Rate
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}

--- a/mysite/utils/data_formatting.py
+++ b/mysite/utils/data_formatting.py
@@ -10,7 +10,7 @@ import yaml
 from babel.dates import format_datetime
 from flask import request, g as session_data
 
-from consts import humanReadableClasses, skillIndexList, emptySkillList, maxCharacters
+from consts import humanReadableClasses, skillIndexList, emptySkillList, maxCharacters, obols_dict
 from models.custom_exceptions import ProfileNotFound, EmptyResponse, APIConnectionFailed, WtfDataException
 
 from .logging import get_logger
@@ -148,6 +148,7 @@ def load_toolbox_data(rawJSON):
     parsed["guildData"] = rawJSON.get("guildData", {})
     parsed["serverVars"] = rawJSON.get("serverVars", {})
     parsed["AutoLoot"] = rawJSON.get("serverVars", {}).get("AutoLoot", 0)
+    parsed['parsedData'] = rawJSON.get('parsedData', {})  #Only available on Public Toolbox profiles
     if not isinstance(parsed.get("AutoLoot"), int):
         try:
             parsed["AutoLoot"] = int(parsed["AutoLoot"])
@@ -303,6 +304,8 @@ def getCharacterDetails(inputJSON, runType):
     equipped_lab_chips = {}
     inventory_bags = {}
     kill_lists = {}
+    obols_list = {}
+    obol_upgrades_list = {}
     big_alch_bubbles_dict = safe_loads(inputJSON.get('CauldronBubbles', [0,0,0] * maxCharacters))
     alchemy_jobs_list = safe_loads(inputJSON.get('CauldronJobs1', [-1] * maxCharacters))
 
@@ -315,6 +318,8 @@ def getCharacterDetails(inputJSON, runType):
         characterSecondaryPresetTalents[character_index] = safe_loads(inputJSON.get(f'SLpre_{character_index}', {}))
         inventory_bags[character_index] = safe_loads(inputJSON.get(f'InvBagsUsed_{character_index}', {}))
         kill_lists[character_index] = safe_loads(inputJSON.get(f'KLA_{character_index}', []))
+        obols_list[character_index] = safe_loads(inputJSON.get(f'ObolEqO0_{character_index}', []))
+        obol_upgrades_list[character_index] = safe_loads(inputJSON.get(f'ObolEqMAP_{character_index}', {}))
         try:
             equipped_lab_chips[character_index] = safe_loads(inputJSON['Lab'])[character_index+1]
         except:
@@ -341,6 +346,8 @@ def getCharacterDetails(inputJSON, runType):
             equipped_lab_chips=equipped_lab_chips[character_index],
             inventory_bags=inventory_bags[character_index],
             kill_dict={k:v for k, v in enumerate(kill_lists[character_index])},
+            obols=obols_list[character_index],
+            obol_upgrades=obol_upgrades_list[character_index],
             big_alch_bubbles=big_alch_bubbles_dict[character_index],
             alchemy_job=alchemy_jobs_list[character_index]
         )
@@ -370,6 +377,30 @@ def getAllSkillLevelsDict(inputJSON, playerCount):
                 logger.exception(f"Unable to retrieve Lv0_{characterIndex}'s Skill level for {skillIndexList[skillCounter]}")
     return allSkillsDict
 
+# This returns incomplete data, since the obols_dict currently only contains DR obols
+# Dispite this, the function is written to work with whatever data is added to the obols_dict
+def get_obol_totals(obol_list, obol_upgrade_dict):
+    obols_totals = {}
+    for obol_index, obol_name in enumerate(obol_list):
+        obol_index = str(obol_index)
+        # Adds the base values for each equipped obol
+        for obol_base_name, obol_base_value in obols_dict.get(obol_name, {}).get('Base', {}).items():
+            obols_totals[f"Total{obol_base_name}"] = obols_totals.get(f"Total{obol_base_name}", 0) + obol_base_value
+        # Adds any upgrade value for each equipped obol
+        if obol_index in obol_upgrade_dict.keys():
+            if 'UQ1txt' in obol_upgrade_dict[obol_index] and obol_upgrade_dict[obol_index]['UQ1txt'] != 0:
+                obols_totals[f"Total{obol_upgrade_dict[obol_index]['UQ1txt']}"] = (
+                    obols_totals.get(f"Total{obol_upgrade_dict[obol_index]['UQ1txt']}", 0)
+                    + obol_upgrade_dict[obol_index]['UQ1val']
+                )
+            if 'UQ2txt' in obol_upgrade_dict[obol_index] and obol_upgrade_dict[obol_index]['UQ2txt'] != 0:
+                obols_totals[f"Total{obol_upgrade_dict[obol_index]['UQ2txt']}"] = (
+                    obols_totals.get(f"Total{obol_upgrade_dict[obol_index]['UQ2txt']}", 0)
+                    + obol_upgrade_dict[obol_index]['UQ2val']
+                )
+            for upgrade_val in ['STR', 'AGI', 'WIS', 'LUK', 'Defence', 'Weapon_Power', 'Reach', 'Speed']:
+                obols_totals[f"Total{upgrade_val}"] = obols_totals.get(f"Total{upgrade_val}", 0) + obol_upgrade_dict.get(upgrade_val, 0)
+    return obols_totals
 
 def getHumanReadableClasses(classNumber):
     return humanReadableClasses.get(classNumber, f"Unknown class: {classNumber}")
@@ -470,6 +501,10 @@ def mark_advice_completed(advice, force=False):
                 complete()
         except:
             pass
+
+    elif advice.percent == '100%':
+        #If the progress bar is set to 100%
+        complete()
 
     else:
         try:

--- a/mysite/utils/text_formatting.py
+++ b/mysite/utils/text_formatting.py
@@ -15,7 +15,7 @@ numeralList = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
 
 def pl(_list, suffix_singular: str = "", suffix_plural: str = "s") -> str:
     """Pluralize"""
-    length = _list if isinstance(_list, int) else len(_list)
+    length = _list if (isinstance(_list, int) or isinstance(_list, float)) else len(_list)
     return suffix_plural if length > 1 else suffix_singular
 
 

--- a/mysite/w1/smithing.py
+++ b/mysite/w1/smithing.py
@@ -69,7 +69,8 @@ def getForgeCapacityAdviceGroup() -> list[AdviceGroup]:
     cap_Advices["Scaling Sources"].append(next(c for c in session_data.account.cards if c.name == 'Godshard Ore').getAdvice())
 
     cap_Advices["Scaling Sources"].append(Advice(
-        label=f"{{{{ Forge Stamp|#stamps }}}}: +{session_data.account.stamps['Forge Stamp']['Value']:.2f}/57.50%",
+        label=f"{{{{ Forge Stamp|#stamps }}}}: +{session_data.account.stamps['Forge Stamp']['Total Value']:.2f}/57.50%"
+              f"Note: Exalting the stamp will take it over the goal listed above",
         picture_class="forge-stamp",
         progression=session_data.account.stamps['Forge Stamp']['Level'],
         goal=230  #Forge Stamp currently has a max of 230, unless it gets increased by the Sacred Methods bundle.

--- a/mysite/w1/stamps.py
+++ b/mysite/w1/stamps.py
@@ -90,12 +90,11 @@ def getCapacityAdviceGroup() -> AdviceGroup:
     ))
     for capStamp in ["Mason Jar Stamp", "Lil' Mining Baggy Stamp", "Choppin' Bag Stamp", "Matty Bag Stamp", "Bag o Heads Stamp", "Bugsack Stamp"]:
         capacity_Advices["Stamps"].append(Advice(
-            label=f"{capStamp}: "
-                  f"{session_data.account.stamps.get(capStamp, {}).get('Level', 0)}/{stamp_maxes.get(capStamp, 999)}%",
+            label=f"{capStamp}: {round(session_data.account.stamps[capStamp]['Total Value'], 2):g}%",
             picture_class=capStamp,
-            progression=session_data.account.stamps.get(capStamp, {}).get('Level', 0),
-            goal=stamp_maxes.get(capStamp, 999),
-            resource=session_data.account.stamps.get(capStamp, {}).get('Material', 0),
+            progression=session_data.account.stamps[capStamp]['Level'],
+            goal=stamp_maxes[capStamp],
+            resource=session_data.account.stamps[capStamp]['Material'],
         ))
 
     # Account-Wide
@@ -109,7 +108,7 @@ def getCapacityAdviceGroup() -> AdviceGroup:
     capacity_Advices["Account Wide"].append(Advice(
         label="Guild Bonus: Rucksack",
         picture_class="rucksack",
-        progression=f"{session_data.account.guildBonuses.get('Rucksack', 0) if session_data.account.guildBonuses.get('Rucksack', 0) > 0 else 'IDK'}",
+        progression=f"{session_data.account.guild_bonuses['Rucksack']['Level'] if session_data.account.guild_bonuses['Rucksack']['Level'] > 0 else 'IDK'}",
         goal=50
     ))
     capacity_Advices["Account Wide"].append(session_data.account.shrine_advices['Pantheon Shrine'])

--- a/mysite/w1/statues.py
+++ b/mysite/w1/statues.py
@@ -32,8 +32,8 @@ def getPreOnyxAdviceGroup() -> AdviceGroup:
         crystal_AdviceList.append(next(c for c in session_data.account.cards if c.name == card_name).getAdvice('Minimum 3 star'))
 
     crystal_AdviceList.append(Advice(
-        label=f"Minimum 100 Crystallin Stamp: {session_data.account.stamps['Crystallin']['Level']} (+{session_data.account.stamps['Crystallin']['Value']:.3f}%)",
-        picture_class="crystallin",
+        label=f"Minimum 100 Crystallin Stamp: {session_data.account.stamps['Crystallin']['Level']} (+{session_data.account.stamps['Crystallin']['Total Value']:.3f}%)",
+        picture_class='crystallin',
         progression=session_data.account.stamps['Crystallin']['Level'],
         goal=100  #stamp_maxes['Crystallin']
     ))

--- a/mysite/w2/alchemy.py
+++ b/mysite/w2/alchemy.py
@@ -667,7 +667,7 @@ def getSigilSpeedAdviceGroup(practical_maxed: bool) -> AdviceGroup:
     )
     willow_vial_value = session_data.account.alchemy_vials['Willow Sippy (Willow Logs)']['Value']
 
-    player_sigil_stamp_value = session_data.account.stamps['Sigil Stamp']['Value']
+    player_sigil_stamp_value = session_data.account.stamps['Sigil Stamp']['Total Value']
     goal_sigil_stamp_value = lavaFunc('decay', stamp_maxes['Sigil Stamp'], 40, 150)
     # The Sigil Stamp is a MISC stamp, thus isn't multiplied by the Lab bonus or Pristine Charm
     # if session_data.account.labBonuses['Certified Stamp Book']['Enabled']:

--- a/mysite/w2/islands.py
+++ b/mysite/w2/islands.py
@@ -97,6 +97,81 @@ def getProgressionTiersAdviceGroup() -> tuple[AdviceGroup, int, int, int]:
     overall_SectionTier = min(max_tier + infoTiers, tier_Islands)
     return tiers_ag, overall_SectionTier, max_tier, max_tier + infoTiers
 
+def getRandomEventItemsAdviceGroup() -> AdviceGroup:
+    items_advice = []
+
+    random_event_items = {
+        'Grumbie the Hatchet Hammer (Mega Grumblo)': {
+            'Code Name': 'EquipmentToolsHatchet11',
+            'Resource': 'mega-grumblo',
+            'Goal': 1,
+            'Image': 'grumbie-the-hatchet-hammer'
+        },
+        'Skewered Snek (Snake Swarm)': {
+            'Code Name': 'EquipmentTools13',
+            'Resource': 'snake-swarm',
+            'Goal': 1,
+            'Image': 'skewered-snek'
+        },
+        'Ice Guard Helmet (Glacial Guild)': {
+            'Code Name': 'EquipmentHats79',
+            'Resource': 'ice-guard',
+            'Goal': 1,
+            'Image': 'ice-guard-helmet'
+        },
+        'Vigilant Obol of Ice Guard (Glacial Guild)': {
+            'Code Name': 'ObolKnight',
+            'Resource': 'ice-guard',
+            'Goal': 1,
+            'Image': 'vigilant-obol-of-ice-guard'
+        },
+        'Meteorhead (Fallen Meteorite)': {
+            'Code Name': 'EquipmentHats78',
+            'Resource': 'fallen-meteor',
+            'Goal': 1,
+            'Image': 'meteorhead'
+        },
+        'Meteorite Ring (Fallen Meteorite)': {
+            'Code Name': 'EquipmentRingsChat10',
+            'Resource': 'fallen-meteor',
+            'Goal': 1,
+            'Image': 'meteorite-ring'
+        },
+        'Grumpy Obol of the Grandfrogger (Angry Frogs)': {
+            'Code Name': 'ObolFrog',
+            'Resource': 'angry-frogs',
+            'Goal': 1,
+            'Image': 'grumpy-obol-of-the-grandfrogger'
+        }
+    }
+
+    total_found = 0
+    total_possible = len(random_event_items)
+
+    for display, details in random_event_items.items():
+        if details['Code Name'] in session_data.account.registered_slab:
+            total_found += 1
+        items_advice.append(Advice(
+            label=display,
+            picture_class=details['Image'],
+            progression=int(details['Code Name'] in session_data.account.registered_slab),
+            goal=1,
+            resource=details['Resource'],
+            informational=True
+        ))
+
+    for advice in items_advice:
+        mark_advice_completed(advice)
+
+    items_ag = AdviceGroup(
+        tier='',
+        pre_string=f"Info- {total_found}/{total_possible} Unique Random Event drops found",
+        advices=items_advice
+    )
+    items_ag.remove_empty_subgroups()
+    return items_ag
+
+
 def getIslandsAdviceSection() -> AdviceSection:
     highestFishingSkillLevel = max(session_data.account.all_skills["Fishing"])
     if highestFishingSkillLevel < 30:
@@ -114,6 +189,7 @@ def getIslandsAdviceSection() -> AdviceSection:
     islands_AdviceGroupDict['Tiers'], overall_SectionTier, max_tier, true_max = getProgressionTiersAdviceGroup()
     islands_AdviceGroupDict['Trash'] = getTrashIslandAdviceGroup()
     islands_AdviceGroupDict['Fractal'] = getFractalAdviceGroup()
+    islands_AdviceGroupDict['Random Event Items'] = getRandomEventItemsAdviceGroup()
 
     #Advice Section
 

--- a/mysite/w3/collider.py
+++ b/mysite/w3/collider.py
@@ -187,7 +187,7 @@ def getCostReductionAdviceGroup() -> AdviceGroup:
     ))
 
     cr_advice.append(Advice(
-        label=f"Atomic Stamp: {session_data.account.stamps['Atomic Stamp']['Value']:.3f}%",
+        label=f"Atomic Stamp: {session_data.account.stamps['Atomic Stamp']['Total Value']:.3f}%",
         picture_class="atomic-stamp",
         progression=session_data.account.stamps['Atomic Stamp']['Level'],
         resource=session_data.account.stamps['Atomic Stamp']['Material'],

--- a/mysite/w3/consDeathNote.py
+++ b/mysite/w3/consDeathNote.py
@@ -59,7 +59,8 @@ def getDeathNoteProgressionTiersAdviceGroup():
         "WOW": {}
     }
     infoTiers = 2
-    max_tier = deathNote_progressionTiers[-1][0] - infoTiers
+    true_max = deathNote_progressionTiers[-1][0]
+    max_tier = true_max - infoTiers
     worldIndexes = []
     tier_combo = {}
     for number in range(1, currentWorld + 1):
@@ -259,17 +260,6 @@ def getDeathNoteProgressionTiersAdviceGroup():
                             goal=1)
                     ]
 
-    # If the player is basically finished with cooking, bypass the requirement while still showing the progress
-    if session_data.account.cooking['MaxRemainingMeals'] < cookingCloseEnough:
-        if tier_combo['ZOW'] < max_tier + infoTiers:
-            tier_combo['ZOW'] = max_tier + infoTiers
-        if tier_combo['CHOW'] < max_tier + infoTiers:
-            tier_combo['CHOW'] = max_tier + infoTiers
-        if tier_combo['MEOW'] < max_tier + infoTiers:
-            tier_combo['MEOW'] = max_tier + infoTiers
-        if tier_combo['WOW'] < max_tier + infoTiers:
-            tier_combo['WOW'] = max_tier + infoTiers
-
     # Generate Advice Groups
     deathnote_AdviceGroupDict = {}
     # Basic Worlds
@@ -339,6 +329,7 @@ def getDeathNoteProgressionTiersAdviceGroup():
             pre_string=f"{'Informational- You could complete' if tier_combo['WOW'] >= max_tier else 'Complete'} {apocToNextTier['WOW']} more"
                        f" WOW{pl(apocToNextTier['WOW'])} with {session_data.account.all_characters[apocalypse_character_Index].character_name} {wowsForNextTier}",
             advices=deathnote_AdviceDict['WOW'],
+            post_string='Aim for 10m+ KPH per enemy',
             informational=True if tier_combo['WOW'] >= max_tier else False
         )
     else:
@@ -354,12 +345,12 @@ def getDeathNoteProgressionTiersAdviceGroup():
             deathnote_AdviceGroupDict[ag.pre_string] = ag
 
     overall_SectionTier = min(
-        max_tier + infoTiers, min(tier_combo.values())
+        true_max, min(tier_combo.values())
         # tier_combo[1], tier_combo[2], tier_combo[3],
         # tier_combo[4], tier_combo[5], tier_combo[6],
         # tier_combo['ZOW'], tier_combo['CHOW'], tier_combo['MEOW'], tier_combo['WOW']
     )
-    return deathnote_AdviceGroupDict, overall_SectionTier, max_tier, max_tier + infoTiers
+    return deathnote_AdviceGroupDict, overall_SectionTier, max_tier, true_max
 
 
 def getDeathNoteAdviceSection() -> AdviceSection:

--- a/mysite/w3/sampling.py
+++ b/mysite/w3/sampling.py
@@ -38,15 +38,9 @@ def getPrinterSampleRateAdviceGroup() -> AdviceGroup:
     account_sum += 0.5 * session_data.account.merits[2][4]['Level']
     account_sum += session_data.account.family_bonuses['Maestro']['Value']
     stample_baseValue = session_data.account.stamps['Stample Stamp']['Value']
-    stampleValue = session_data.account.stamps['Stample Stamp']['Value']
+    stampleValue = session_data.account.stamps['Stample Stamp']['Total Value']
     amplestample_baseValue = session_data.account.stamps['Amplestample Stamp']['Value']
-    amplestampleValue = session_data.account.stamps['Amplestample Stamp']['Value']
-    if session_data.account.labBonuses['Certified Stamp Book']['Enabled']:
-        stampleValue *= 2
-        amplestampleValue *= 2
-    if session_data.account.sneaking['PristineCharms']['Liqorice Rolle']['Obtained']:
-        stampleValue *= 1.25
-        amplestampleValue *= 1.25
+    amplestampleValue = session_data.account.stamps['Amplestample Stamp']['Total Value']
     account_sum += stampleValue
     account_sum += amplestampleValue
     account_sum += float(session_data.account.arcade.get(5, {}).get('Value', 0))
@@ -290,7 +284,7 @@ def getPrinterOutputAdviceGroup() -> AdviceGroup:
             bestKotRPresetLevel = dk.secondary_preset_talents.get("178", 0) + levels_above_max
 
     talent_value = lavaFunc('decay', bestKotRPresetLevel, 5, 150)
-    orb_kills = session_data.account.dk_orb_kills
+    orb_kills = session_data.account.class_kill_talents['King of the Remembered']['Kills']
     pow10_kills = math.log(orb_kills,10) if orb_kills > 0 else 0
     kotr_multi = max(1, ValueToMulti(talent_value * pow10_kills))
 

--- a/mysite/w6/farming.py
+++ b/mysite/w6/farming.py
@@ -395,7 +395,7 @@ def getEvoChanceAdviceGroup(farming) -> AdviceGroup:
     ))
     evo_advices[stamp].append(Advice(
         label=f"Crop Evo {{{{ Stamp|#stamps}}}}: {session_data.account.stamps['Crop Evo Stamp']['Value']:.0f}%"
-              f"<br>Total Value after multis: {farming['Evo']['Stamp Value']:.2f}%",
+              f"<br>Total Value after multis: {session_data.account.stamps['Crop Evo Stamp']['Total Value']:.2f}%",
         picture_class='crop-evo-stamp',
         progression=session_data.account.stamps['Crop Evo Stamp']['Level'],
         goal=stamp_maxes['Crop Evo Stamp'],


### PR DESCRIPTION
## 2025-05-16
### New Section: General > Drop Rate
* Account-Wide bonuses, grouped by individual world where you earn (or apply) the buff
* Character specific bonuses grouped into Cards, Equipment, and other Miscellaneous buffs
* Huge thanks to @lakofcreativity for putting this new section together

### General > Gem Shop
* Added tracking for World Kill Rings and the DB/WW master class premium hats
### W2 > Islands
* Added tracking for the 7 unique drops from Random Event bosses
### W3 > Atom Collider
* Updated T14's Aluminium goal from 30 to 50
* Added additional Atoms with goals up to 50 as well
### W3 > Death Note
* Removed Wood Mushrooms from being required in the W1 minimum skull requirement
* Moved Apocalypse stacks into earlier tiers
* Remove the Apocalypse stack bypass from cooking meal levels. WOWs require more kills and provide benefit outside of Cooking, so shouldn't be skipped any longer.
* Reduce total tiers from 27 to 24
### W5 > Slab
* The `Storage, Inventory, or Equipped items` group now includes the source of the item for your account
* Removed the Mining and Class certificates as they're no longer obtainable
* Updated the quest you can reclaim the Junk Pickaxe from
### W6 > Farming
* Land Rank values updated to include the best Dank Rank's talent on any DB preset. Note: This means it may be inaccurate if you aren't using that preset.