### PR TITLE
Beta 2025 05 24 (#278)

### DIFF
--- a/changelog/CHANGELOG
+++ b/changelog/CHANGELOG
@@ -1,3 +1,4 @@
+2025-05-25: Vault T3 fix, Alchemy T7-9 tweaks, Breeding T13-15 added
 2025-05-19: New Drop Rate section + Death Note and Atom Collider Tier changes
 2025-05-12: Add Tiers for Endangered Greenstacks, Vault, Post Office
 2025-05-06: Master Classes category, Bone multi breakdown, Dust multi breakdown

--- a/mysite/consts.py
+++ b/mysite/consts.py
@@ -405,10 +405,6 @@ achievements_progressionTiers = {
             'Skill Master': {'World': 2, 'Reward': 'W2 Key', 'Rating': ''},
             'Cool Score!': {'World': 3, 'Reward': 'W3 Colo and Shop', 'Rating': ''},
         },
-        # 'Free Teleports': {
-        #     'Nice Fur Suit': {'World': 1, 'Reward': 'Free Teleport to Encroaching Forest Villas / Wode Boards / Amarok', 'Rating': ''},
-        #     "Million Null 'n Void": {'World': 1, 'Reward': 'Free Teleport to Echoing Egress / Void Ore', 'Rating': ''},
-        # },
         'Monster Respawn': {},
         'Recipes': {
             'Based Roots': {'World': 1, 'Reward': 'Acorn Hat', 'Rating': ''},
@@ -830,7 +826,7 @@ vault_progressionTiers = {
         ]  #This list generated from Acecow's alt account when they first entered World 6
     },
     3: {
-        'Exclude': ['Wicked Smart', 'Kitchen Dream-mare', 'Teh TOM', 'Cooking Knowledge']
+        'Exclude': ['Wicked Smart', 'Kitchen Dream-mare', 'Teh TOM', 'Cooking Knowledge', 'Card Retirement']
     }
 }
 
@@ -885,21 +881,20 @@ bubbles_progressionTiers = [
      {'Roid Ragin': 234, 'Warriors Rule': 117, 'Hearty Diggy': 234, 'Wyoming Blood': 70, 'Sploosh Sploosh': 70, 'Stronk Tools': 164, 'Multorange': 70,
       'Dream Of Ironfish': 70},
      {'Swift Steppin': 234, 'Archer Or Bust': 117, 'Bug^2': 70, 'Premigreen': 70, 'Fly In Mind': 94},
-     {'Stable Jenius': 234, 'Mage Is Best': 117, 'Molto Loggo': 70, 'Le Brain Tools': 164, 'Severapurple': 70, 'Tree Sleeper': 94},
+     {'Stable Jenius': 234, 'Mage Is Best': 117, 'Molto Loggo': 70, 'Le Brain Tools': 164, 'Severapurple': 70},
      {'All For Kill': 150, "Name I Guess": 100},
      "70% max value",
      ""],
     [7, 120,
-     {'Roid Ragin': 400, 'Warriors Rule': 200, 'Hearty Diggy': 400, 'Wyoming Blood': 120, 'Sploosh Sploosh': 120, 'Stronk Tools': 280, 'Multorange': 120,
-      'Dream Of Ironfish': 120},
-     {'Swift Steppin': 400, 'Archer Or Bust': 200, 'Bug^2': 120, 'Premigreen': 120},
+     {'Roid Ragin': 400, 'Warriors Rule': 200, 'Hearty Diggy': 400, 'Wyoming Blood': 120, 'Sploosh Sploosh': 120, 'Stronk Tools': 280, 'Multorange': 120},
+     {'Swift Steppin': 400, 'Archer Or Bust': 200, 'Bug^2': 120},
      {'Stable Jenius': 400, 'Mage Is Best': 200, 'Hocus Choppus': 400, 'Molto Loggo': 120, 'Le Brain Tools': 280, 'Severapurple': 120, 'Tree Sleeper': 160},
      {'Laaarrrryyyy': 150, 'Hammer Hammer': 150, 'Cookin Roadkill': 105, 'All For Kill': 167},
      "80% max value",
      "Larry at 150 = 72% chance for +2 levels. Somewhere around level 125-150, this bubble should pass 100m Dementia Ore cost and be available to level with Boron upgrades from the W3 Atom Collider in Construction.  It should be, in my opinion, the ONLY Utility Bubble you spend these daily clicks on until it reaches 501. If you cannot afford the Particles needed to level Larry, invest into Sampling Bubbles."],
     [8, 120,
      {'Roid Ragin': 567, 'Warriors Rule': 284, 'Hearty Diggy': 567, 'Stronk Tools': 397, 'Multorange': 170, 'Dream Of Ironfish': 170},
-     {'Swift Steppin': 567, 'Premigreen': 170},
+     {'Swift Steppin': 567},
      {'Stable Jenius': 567, 'Mage Is Best': 284, 'Hocus Choppus': 567, 'Le Brain Tools': 397, 'Severapurple': 170, 'Tree Sleeper': 227},
      {'Hammer Hammer': 180},
      "85% max value",
@@ -909,7 +904,7 @@ bubbles_progressionTiers = [
      {'Swift Steppin': 740, 'Archer Or Bust': 450, 'Premigreen': 270},
      {'Stable Jenius': 740, 'Mage Is Best': 450, 'Hocus Choppus': 900, 'Le Brain Tools': 630, 'Severapurple': 270, 'Tree Sleeper': 360},
      {'Laaarrrryyyy': 501, 'Cookin Roadkill': 630, 'Startue Exp': 240, 'Hammer Hammer': 300,
-      'Droppin Loads': 280, 'Shimmeron': 360, 'Buff Boi Talent': 100, 'Fast Boi Talent': 100, 'Smart Boi Talent': 100,},
+      'Droppin Loads': 280, 'Buff Boi Talent': 100, 'Fast Boi Talent': 100, 'Smart Boi Talent': 100},
      "90% max value",
      ""],
     [10, 120,
@@ -977,7 +972,7 @@ bubbles_progressionTiers = [
      {'Stable Jenius': 10000, 'Mage Is Best': 4950, 'Hocus Choppus': 9900, 'Le Brain Tools': 6930, 'Severapurple': 2970, 'Tree Sleeper': 3960,
       'Slabe Logsoul': 5940, 'Slabe Wisdom': 5940, 'Endgame Eff III': 5940, 'Tome Wisdom': 5940},
      {'Cookin Roadkill': 6930, 'Call Me Bob': 10000, 'Carpenter': 4950, 'Nickel Of Wisdom': 2970, "Penny Of Strength": 2970, "Dollar Of Agility": 2970,
-      'Droppin Loads': 6930, 'Startue Exp': 5940, 'Laaarrrryyyy': 9900, 'Big Game Hunter': 2970, 'Mr Massacre': 4950, 'Big P': 5940, 'Shimmeron': 3960,
+      'Droppin Loads': 6930, 'Startue Exp': 5940, 'Laaarrrryyyy': 9900, 'Big Game Hunter': 2970, 'Mr Massacre': 4950, 'Big P': 5940,
       'Hammer Hammer': 10000, "Grind Time": 10000, 'Buff Boi Talent': 800, 'Fast Boi Talent': 800, 'Smart Boi Talent': 800,
       'Card Champ': 3960,
       'Essence Chapter': 4950, 'Quickdraw Quiver': 5940, 'Smarter Spells': 5940, 'Ninja Looter': 5940, 'Crop Chapter': 4950
@@ -1416,146 +1411,167 @@ sampling_progressionTiers = {
 
 ###WORLD 4 PROGRESSION TIERS###
 breeding_progressionTiers = {
-        0: {
-            "Tier": 0,
-            "TerritoriesUnlocked": 0,
-            "PetSlots": 2,
-            "TerritoryNotes": "",
-            "ArenaWaves": 0,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        1: {
-            "Tier": 1,
-            "TerritoriesUnlocked": 3,
-            "PetSlots": 3,
-            "TerritoryNotes": "",
-            "ArenaWaves": 3,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        2: {
-            "Tier": 2,
-            "TerritoriesUnlocked": 7,
-            "PetSlots": 4,
-            "TerritoryNotes": "",
-            "ArenaWaves": 15,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        3: {
-            "Tier": 3,
-            "TerritoriesUnlocked": 10,
-            "PetSlots": 4,
-            "TerritoryNotes": "",
-            "ArenaWaves": 50,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        4: {
-            "Tier": 4,
-            "TerritoriesUnlocked": 14,
-            "PetSlots": 5,
-            "TerritoryNotes": "",
-            "ArenaWaves": 125,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        5: {
-            "Tier": 5,
-            "TerritoriesUnlocked": 20,
-            "PetSlots": 6,
-            "TerritoryNotes": "",
-            "ArenaWaves": 200,
-            "ArenaNotes": "",
-            "Shinies": {},
-            "ShinyNotes": ""
-            },
-        #0-5 are Territory/Arena focused.
-        #6 is blended
-        #7+ are Shiny focused
-        6: {
-            "Tier": 6,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Faster Shiny Pet Lv Up Rate": [24, 6],
-                "Bonuses from All Meals": [10, 5],
-                "Infinite Star Signs": [25, 5],
-                "Base Efficiency for All Skills": [20, 5],
-            },
-            "ShinyNotes": "Start by focusing on pets that increase Shiny Speed rate. This will decrease the amount of time needed to level up pets in the future."
-            },
-        7: {
-            "Tier": 7,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Base Critter Per Trap": [10, 5],
-                "Drop Rate": [15, 5],
-                "Faster Refinery Speed": [15, 5],
-                "Lower Minimum Travel Time for Sailing": [5, 5],
-                },
-            "ShinyNotes": ""
-            },
-        8: {
-            "Tier": 8,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Multikill Per Tier": [20, 5],
-                "Higher Artifact Find Chance": [15, 5],
-                "Faster Shiny Pet Lv Up Rate": [28, 7],
-                "Infinite Star Signs": [37, 7],
-                "Summoning EXP": [10, 5]
-                },
-            "ShinyNotes": ""
-            },
-        9: {
-            "Tier": 9,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Bonuses from All Meals": [26, 13],
-                "Base Efficiency for All Skills": [48, 12],
-                },
-            "ShinyNotes": ""
+    0: {
+        "Tier": 0,
+        "TerritoriesUnlocked": 0,
+        "PetSlots": 2,
+        "TerritoryNotes": "",
+        "ArenaWaves": 0,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
         },
-        10: {
-            "Tier": 10,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Drop Rate": [36, 12],
-                "Base Critter Per Trap": [22, 11],
-                },
-            "ShinyNotes": ""
+    1: {
+        "Tier": 1,
+        "TerritoriesUnlocked": 3,
+        "PetSlots": 3,
+        "TerritoryNotes": "",
+        "ArenaWaves": 3,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
         },
-        11: {
-            "Tier": 11,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Summoning EXP": [22, 11],
-                "Faster Refinery Speed": [33, 11],
-                "Multikill Per Tier": [44, 11],
-            },
-            "ShinyNotes": ""
+    2: {
+        "Tier": 2,
+        "TerritoriesUnlocked": 7,
+        "PetSlots": 4,
+        "TerritoryNotes": "",
+        "ArenaWaves": 15,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
         },
-        12: {
-            "Tier": 12,
-            "TerritoriesUnlocked": 24,
-            "ArenaWaves": 200,
-            "Shinies": {
-                "Infinite Star Signs": [45, 8],
+    3: {
+        "Tier": 3,
+        "TerritoriesUnlocked": 10,
+        "PetSlots": 4,
+        "TerritoryNotes": "",
+        "ArenaWaves": 50,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
+        },
+    4: {
+        "Tier": 4,
+        "TerritoriesUnlocked": 14,
+        "PetSlots": 5,
+        "TerritoryNotes": "",
+        "ArenaWaves": 125,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
+        },
+    5: {
+        "Tier": 5,
+        "TerritoriesUnlocked": 20,
+        "PetSlots": 6,
+        "TerritoryNotes": "",
+        "ArenaWaves": 200,
+        "ArenaNotes": "",
+        "Shinies": {},
+        "ShinyNotes": ""
+        },
+    #0-5 are Territory/Arena focused.
+    #6 is blended
+    #7+ are Shiny focused
+    6: {
+        "Tier": 6,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Faster Shiny Pet Lv Up Rate": [24, 6],
+            "Bonuses from All Meals": [10, 5],
+            "Infinite Star Signs": [25, 5],
+            "Base Efficiency for All Skills": [20, 5],
+        },
+        "ShinyNotes": "Start by focusing on pets that increase Shiny Speed rate. This will decrease the amount of time needed to level up pets in the future."
+        },
+    7: {
+        "Tier": 7,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Base Critter Per Trap": [10, 5],
+            "Drop Rate": [15, 5],
+            "Faster Refinery Speed": [15, 5],
+            "Lower Minimum Travel Time for Sailing": [5, 5],
             },
-            "ShinyNotes": ""
-        }
+        "ShinyNotes": ""
+        },
+    8: {
+        "Tier": 8,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Multikill Per Tier": [20, 5],
+            "Higher Artifact Find Chance": [15, 5],
+            "Faster Shiny Pet Lv Up Rate": [28, 7],
+            "Infinite Star Signs": [37, 7],
+            "Summoning EXP": [10, 5]
+            },
+        "ShinyNotes": ""
+        },
+    9: {
+        "Tier": 9,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Bonuses from All Meals": [26, 13],
+            "Base Efficiency for All Skills": [48, 12],
+            },
+        "ShinyNotes": ""
+    },
+    10: {
+        "Tier": 10,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Drop Rate": [36, 12],
+            "Base Critter Per Trap": [22, 11],
+            },
+        "ShinyNotes": ""
+    },
+    11: {
+        "Tier": 11,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Summoning EXP": [22, 11],
+            "Faster Refinery Speed": [33, 11],
+            "Multikill Per Tier": [44, 11],
+        },
+        "ShinyNotes": ""
+    },
+    12: {
+        "Tier": 12,
+        "TerritoriesUnlocked": 24,
+        "ArenaWaves": 200,
+        "Shinies": {
+            "Infinite Star Signs": [45, 8],
+        },
+        "ShinyNotes": ""
+    },
+    13: {
+        'Max Shinies': [
+            'Bonuses from All Meals', 'Drop Rate', 'Summoning EXP',
+            'Base Efficiency for All Skills', 'Multikill Per Tier', 'Faster Refinery Speed'
+        ]
+    },
+    14: {
+        'Max Shinies': [
+            'Farming EXP', 'Lower Minimum Travel Time for Sailing', 'Sail Captain EXP Gain',
+            'Higher Artifact Find Chance', 'Skill EXP', 'Base Critter Per Trap'
+        ]
+    },
+    15: {
+        'Max Shinies': [
+            'Faster Shiny Pet Lv Up Rate', 'Base WIS', 'Base STR', 'Base AGI', 'Base LUK',
+            'Infinite Star Signs', 'Total Damage',
+            'Tab 4 Talent Pts', 'Tab 3 Talent Pts', 'Tab 2 Talent Pts', 'Tab 1 Talent Pts',
+            'Class EXP', 'Line Width in Lab'
+        ]
+    },
+
     }
 rift_progressionTiers = {
     0: [0,  "",             0],
@@ -2263,7 +2279,7 @@ expectedStackables = {
         "EquipmentStatues1", "EquipmentStatues5",  # Plausible but time consuming
         "EquipmentStatues10", "EquipmentStatues12", "EquipmentStatues13", "EquipmentStatues8", "EquipmentStatues11",  # W2 statues are all slower than Power/Health
         "rtt0", "StoneZ1", "StoneT1", "StoneW1", "StoneA1",  #W1 Slow drops = Town TP + Stones
-        "StoneT2", "StoneZ2",  "StoneW2", "StoneA2", # W2 upgrade stones and Mystery2
+        "StoneT2", "StoneZ2",  "StoneW2", "StoneA2",  # W2 upgrade stones and Mystery2
         "PureWater", "EquipmentStatues18",  #W3 Slow drops = Distilled Water + EhExPee Statue
         "EquipmentStatues20", "EquipmentStatues21", "EquipmentStatues22",  # W4 Statues
         "EquipmentStatues23", "EquipmentStatues24", "EquipmentStatues25", "FoodG9",  #W5 Slow drops = Golden W5 Sammy + Statues
@@ -3419,7 +3435,7 @@ guild_bonuses_dict = {
     'Multi Tool': {'Image': 'multi-tool', 'Max Level': 50, 'Max Value': 15, 'funcType': 'decay', 'x1': 30, 'x2': 50},
     'Skilley Skiller': {'Image': 'skilley-skiller', 'Max Level': 50, 'Max Value': 5, 'funcType': 'decay', 'x1': 10, 'x2': 50},
     'Coin Supercharger': {'Image': 'coin-supercharger', 'Max Level': 100, 'Max Value': 16.667, 'funcType': 'decay', 'x1': 20, 'x2': 20},
-    'Bonus GP for small guilds': {'Image': 'bonus-gp-for-small-guilds', 'Max Level': 50, 'Max Value': 0, 'funcType': 'special1', 'x1': 200, 'x2': 50}, # This value decreases to a min value of 0
+    'Bonus GP for small guilds': {'Image': 'bonus-gp-for-small-guilds', 'Max Level': 50, 'Max Value': 0, 'funcType': 'special1', 'x1': 200, 'x2': 50},  # This value decreases to a min value of 0
     'Gold Charm': {'Image': 'gold-charm', 'Max Level': 50, 'Max Value': 20, 'funcType': 'decay', 'x1': 40, 'x2': 50},
     'Star Dazzle': {'Image': 'star-dazzle', 'Max Level': 50, 'Max Value': 60, 'funcType': 'decay', 'x1': 120, 'x2': 50},
     'C2 Card Spotter': {'Image': 'c2-card-spotter', 'Max Level': 50, 'Max Value': 30, 'funcType': 'decay', 'x1': 60, 'x2': 50},
@@ -4819,7 +4835,7 @@ filter_recipes = {
     "Beginner Recipe": [
         "Copper Band", "Iron Boots", "Steel Band", "Goo Galoshes", "Fur Shirt", "Dooble Goopi", "Bleached Designer Wode Patch Pants",
         "Serrated Rex Ring", "Fishing Overalls", "Bandito Pantaloon",
-        "Blue Tee", "Peanut", "Golden Peanut",  #IDK about including these. They're technically from quests but maybe they count too? :shrug:
+        "Blue Tee", "Peanut", "Golden Peanut",  #IDK about including these. They're technically from quests, but maybe they count too? :shrug:
     ],
     "Novice Recipe": [
         "Defenders Dignity", "Strung Bludgeon", "Polished Bludgeon", "Googley Eyes", "Dootjat Eye", "Protectors Pride", "Skullfish Pendant",
@@ -8463,7 +8479,7 @@ cropDepotDict = {
 
 }
 cropDict = {
-#Basic
+    #Basic
     #0: {'Name': '', 'Image': '', 'SeedName': 'Earthy', 'SeedCropIndex': None},
     1: {'Name': 'Apple', 'Image': 'apple-crop', 'SeedName': 'Basic', 'SeedCropIndex': 1},
     2: {'Name': 'Orange', 'Image': 'orange', 'SeedName': 'Basic', 'SeedCropIndex': 2},
@@ -8486,7 +8502,8 @@ cropDict = {
     19: {'Name': 'Dragon Fruit', 'Image': 'dragon-fruit', 'SeedName': 'Basic', 'SeedCropIndex': 19},
     20: {'Name': 'Mango', 'Image': 'mango', 'SeedName': 'Basic', 'SeedCropIndex': 20},
     21: {'Name': 'Gold Blueberry', 'Image': 'gold-blueberry', 'SeedName': 'Basic', 'SeedCropIndex': 21},
-#Earthy
+
+    #Earthy
     22: {'Name': 'Carrot', 'Image': 'carrot', 'SeedName': 'Earthy', 'SeedCropIndex': 1},
     23: {'Name': 'Potato', 'Image': 'potato', 'SeedName': 'Earthy', 'SeedCropIndex': 2},
     24: {'Name': 'Beat', 'Image': 'beat', 'SeedName': 'Earthy', 'SeedCropIndex': 3},
@@ -8512,7 +8529,8 @@ cropDict = {
     44: {'Name': 'Bell Pepper', 'Image': 'bell-pepper', 'SeedName': 'Earthy', 'SeedCropIndex': 23},
     45: {'Name': 'Corn', 'Image': 'corn-crop', 'SeedName': 'Earthy', 'SeedCropIndex': 24},
     46: {'Name': 'Gold Sliced Tomato', 'Image': 'gold-sliced-tomato', 'SeedName': 'Earthy', 'SeedCropIndex': 25},
-#Bulbo
+
+    #Bulbo
     47: {'Name': 'Daisy', 'Image': 'daisy', 'SeedName': 'Bulbo', 'SeedCropIndex': 1},
     48: {'Name': 'Flour', 'Image': 'flour', 'SeedName': 'Bulbo', 'SeedCropIndex': 2},
     49: {'Name': 'Stargazer Lily', 'Image': 'stargazer-lily', 'SeedName': 'Bulbo', 'SeedCropIndex': 3},
@@ -8528,7 +8546,8 @@ cropDict = {
     59: {'Name': 'Muffin', 'Image': 'muffin', 'SeedName': 'Bulbo', 'SeedCropIndex': 13},
     60: {'Name': 'Black Rose', 'Image': 'black-rose', 'SeedName': 'Bulbo', 'SeedCropIndex': 14},
     61: {'Name': 'Golden Tulip', 'Image': 'golden-tulip', 'SeedName': 'Bulbo', 'SeedCropIndex': 15},
-#Sushi
+
+    #Sushi
     62: {'Name': 'Sushi Crop 1', 'Image': 'sushi-crop-1', 'SeedName': 'Sushi', 'SeedCropIndex': 1},
     63: {'Name': 'Sushi Crop 2', 'Image': 'sushi-crop-2', 'SeedName': 'Sushi', 'SeedCropIndex': 2},
     64: {'Name': 'Sushi Crop 3', 'Image': 'sushi-crop-3', 'SeedName': 'Sushi', 'SeedCropIndex': 3},
@@ -8552,7 +8571,8 @@ cropDict = {
     82: {'Name': 'Sushi Crop 21', 'Image': 'sushi-crop-21', 'SeedName': 'Sushi', 'SeedCropIndex': 21},
     83: {'Name': 'Sushi Crop 22', 'Image': 'sushi-crop-22', 'SeedName': 'Sushi', 'SeedCropIndex': 22},
     84: {'Name': 'Sushi Crop 23', 'Image': 'sushi-crop-23', 'SeedName': 'Sushi', 'SeedCropIndex': 23},
-#Mushie
+
+    #Mushie
     85:  {'Name': 'Mushroom 1', 'Image': 'mushroom-1', 'SeedName': 'Mushie', 'SeedCropIndex': 1},
     86:  {'Name': 'Mushroom 2', 'Image': 'mushroom-2', 'SeedName': 'Mushie', 'SeedCropIndex': 2},
     87:  {'Name': 'Mushroom 3', 'Image': 'mushroom-3', 'SeedName': 'Mushie', 'SeedCropIndex': 3},
@@ -8576,7 +8596,8 @@ cropDict = {
     105: {'Name': 'Mushroom 21', 'Image': 'mushroom-21', 'SeedName': 'Mushie', 'SeedCropIndex': 21},
     106: {'Name': 'Mushroom 22', 'Image': 'mushroom-22', 'SeedName': 'Mushie', 'SeedCropIndex': 22},
     107: {'Name': 'Mushroom 23', 'Image': 'mushroom-23', 'SeedName': 'Mushie', 'SeedCropIndex': 23},
-#Normal Glassy
+
+    #Normal Glassy
     108: {'Name': 'Glassy Bananas', 'Image': 'glassy-bananas', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 1},
     109: {'Name': 'Glassy Mango', 'Image': 'glassy-mango', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 2},
     110: {'Name': 'Glassy Mushroom', 'Image': 'glassy-mushroom', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 3},
@@ -8590,7 +8611,8 @@ cropDict = {
     118: {'Name': 'Glassy Lettuce', 'Image': 'glassy-lettuce', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 11},
     119: {'Name': 'Glassy Onigiri', 'Image': 'glassy-onigiri', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 12},
     120: {'Name': 'Glassy Corn', 'Image': 'glassy-corn', 'SeedName': 'Normal Glassy', 'SeedCropIndex': 13},
-#Red Glassy
+
+    #Red Glassy
     121: {'Name': 'Red Glassy Bananas',     'Image': 'red-glassy-bananas', 'SeedName': 'Red Glassy',    'SeedCropIndex': 14},
     122: {'Name': 'Red Glassy Mango',       'Image': 'red-glassy-mango', 'SeedName': 'Red Glassy',      'SeedCropIndex': 15},
     123: {'Name': 'Red Glassy Broccoli',    'Image': 'red-glassy-broccoli', 'SeedName': 'Red Glassy',   'SeedCropIndex': 16},
@@ -8601,7 +8623,8 @@ cropDict = {
     128: {'Name': 'Red Glassy Rose',        'Image': 'red-glassy-rose', 'SeedName': 'Red Glassy',       'SeedCropIndex': 21},
     129: {'Name': 'Red Glassy Onigiri',     'Image': 'red-glassy-corn', 'SeedName': 'Red Glassy',       'SeedCropIndex': 22},
     130: {'Name': 'Red Glassy Corn',        'Image': 'red-glassy-corn', 'SeedName': 'Red Glassy',       'SeedCropIndex': 23},
-#Green Glassy
+
+    #Green Glassy
     131: {'Name': 'Green Glassy Bananas',     'Image': 'green-glassy-bananas', 'SeedName': 'Green Glassy',    'SeedCropIndex': 24},
     132: {'Name': 'Green Glassy Mango',       'Image': 'green-glassy-mango', 'SeedName': 'Green Glassy',      'SeedCropIndex': 25},
     133: {'Name': 'Green Glassy Broccoli',    'Image': 'green-glassy-broccoli', 'SeedName': 'Green Glassy',   'SeedCropIndex': 26},
@@ -8612,7 +8635,8 @@ cropDict = {
     138: {'Name': 'Green Glassy Rose',        'Image': 'green-glassy-rose', 'SeedName': 'Green Glassy',       'SeedCropIndex': 31},
     139: {'Name': 'Green Glassy Onigiri',     'Image': 'green-glassy-corn', 'SeedName': 'Green Glassy',       'SeedCropIndex': 32},
     140: {'Name': 'Green Glassy Corn',        'Image': 'green-glassy-corn', 'SeedName': 'Green Glassy',       'SeedCropIndex': 33},
-#White Glassy
+
+    #White Glassy
     141: {'Name': 'White Glassy Bananas',     'Image': 'white-glassy-bananas', 'SeedName': 'White Glassy',    'SeedCropIndex': 34},
     142: {'Name': 'White Glassy Mango',       'Image': 'white-glassy-mango', 'SeedName': 'White Glassy',      'SeedCropIndex': 35},
     143: {'Name': 'White Glassy Broccoli',    'Image': 'white-glassy-broccoli', 'SeedName': 'White Glassy',   'SeedCropIndex': 36},
@@ -8623,7 +8647,8 @@ cropDict = {
     148: {'Name': 'White Glassy Rose',        'Image': 'white-glassy-rose', 'SeedName': 'White Glassy',       'SeedCropIndex': 41},
     149: {'Name': 'White Glassy Onigiri',     'Image': 'white-glassy-corn', 'SeedName': 'White Glassy',       'SeedCropIndex': 42},
     150: {'Name': 'White Glassy Corn',        'Image': 'white-glassy-corn', 'SeedName': 'White Glassy',       'SeedCropIndex': 43},
-#Purple Glassy
+
+    #Purple Glassy
     151: {'Name': 'Purple Glassy Bananas',     'Image': 'purple-glassy-bananas', 'SeedName': 'Purple Glassy',    'SeedCropIndex': 44},
     152: {'Name': 'Purple Glassy Mango',       'Image': 'purple-glassy-mango', 'SeedName': 'Purple Glassy',      'SeedCropIndex': 45},
     153: {'Name': 'Purple Glassy Broccoli',    'Image': 'purple-glassy-broccoli', 'SeedName': 'Purple Glassy',   'SeedCropIndex': 46},
@@ -8634,7 +8659,8 @@ cropDict = {
     158: {'Name': 'Purple Glassy Rose',        'Image': 'purple-glassy-rose', 'SeedName': 'Purple Glassy',       'SeedCropIndex': 51},
     159: {'Name': 'Purple Glassy Onigiri',     'Image': 'purple-glassy-corn', 'SeedName': 'Purple Glassy',       'SeedCropIndex': 52},
     160: {'Name': 'Purple Glassy Corn',        'Image': 'purple-glassy-corn', 'SeedName': 'Purple Glassy',       'SeedCropIndex': 53},
-#Yellow Glassy
+
+    #Yellow Glassy
     161: {'Name': 'Yellow Glassy Bananas',     'Image': 'yellow-glassy-bananas', 'SeedName': 'Yellow Glassy',    'SeedCropIndex': 54},
     162: {'Name': 'Yellow Glassy Mango',       'Image': 'yellow-glassy-mango', 'SeedName': 'Yellow Glassy',      'SeedCropIndex': 55},
     163: {'Name': 'Yellow Glassy Broccoli',    'Image': 'yellow-glassy-broccoli', 'SeedName': 'Yellow Glassy',   'SeedCropIndex': 56},
@@ -8645,7 +8671,8 @@ cropDict = {
     168: {'Name': 'Yellow Glassy Rose',        'Image': 'yellow-glassy-rose', 'SeedName': 'Yellow Glassy',       'SeedCropIndex': 61},
     169: {'Name': 'Yellow Glassy Onigiri',     'Image': 'yellow-glassy-corn', 'SeedName': 'Yellow Glassy',       'SeedCropIndex': 62},
     170: {'Name': 'Yellow Glassy Corn',        'Image': 'yellow-glassy-corn', 'SeedName': 'Yellow Glassy',       'SeedCropIndex': 63},
-#Blue Glassy
+
+    #Blue Glassy
     171: {'Name': 'Blue Glassy Bananas',     'Image': 'blue-glassy-bananas', 'SeedName': 'Blue Glassy',    'SeedCropIndex': 64},
     172: {'Name': 'Blue Glassy Mango',       'Image': 'blue-glassy-mango', 'SeedName': 'Blue Glassy',      'SeedCropIndex': 65},
     173: {'Name': 'Blue Glassy Broccoli',    'Image': 'blue-glassy-broccoli', 'SeedName': 'Blue Glassy',   'SeedCropIndex': 66},
@@ -8656,7 +8683,8 @@ cropDict = {
     178: {'Name': 'Blue Glassy Rose',        'Image': 'blue-glassy-rose', 'SeedName': 'Blue Glassy',       'SeedCropIndex': 71},
     179: {'Name': 'Blue Glassy Onigiri',     'Image': 'blue-glassy-corn', 'SeedName': 'Blue Glassy',       'SeedCropIndex': 72},
     180: {'Name': 'Blue Glassy Corn',        'Image': 'blue-glassy-corn', 'SeedName': 'Blue Glassy',       'SeedCropIndex': 73},
-#T08 Glassy
+
+    #T08 Glassy
     181: {'Name': 'T08 Glassy Bananas',     'Image': 't08-glassy-bananas',      'SeedName': 'T08 Glassy', 'SeedCropIndex': 74},
     182: {'Name': 'T08 Glassy Mango',       'Image': 't08-glassy-mango',        'SeedName': 'T08 Glassy', 'SeedCropIndex': 75},
     183: {'Name': 'T08 Glassy Broccoli',    'Image': 't08-glassy-broccoli',     'SeedName': 'T08 Glassy', 'SeedCropIndex': 76},
@@ -8667,7 +8695,8 @@ cropDict = {
     188: {'Name': 'T08 Glassy Rose',        'Image': 't08-glassy-rose',         'SeedName': 'T08 Glassy', 'SeedCropIndex': 81},
     189: {'Name': 'T08 Glassy Onigiri',     'Image': 't08-glassy-corn',         'SeedName': 'T08 Glassy', 'SeedCropIndex': 82},
     190: {'Name': 'T08 Glassy Corn',        'Image': 't08-glassy-corn',         'SeedName': 'T08 Glassy', 'SeedCropIndex': 83},
-#T09 Glassy
+
+    #T09 Glassy
     191: {'Name': 'T09 Glassy Bananas',     'Image': 't09-glassy-bananas',      'SeedName': 'T09 Glassy', 'SeedCropIndex': 84},
     192: {'Name': 'T09 Glassy Mango',       'Image': 't09-glassy-mango',        'SeedName': 'T09 Glassy', 'SeedCropIndex': 85},
     193: {'Name': 'T09 Glassy Broccoli',    'Image': 't09-glassy-broccoli',     'SeedName': 'T09 Glassy', 'SeedCropIndex': 86},
@@ -8678,7 +8707,8 @@ cropDict = {
     198: {'Name': 'T09 Glassy Rose',        'Image': 't09-glassy-rose',         'SeedName': 'T09 Glassy', 'SeedCropIndex': 91},
     199: {'Name': 'T09 Glassy Onigiri',     'Image': 't09-glassy-corn',         'SeedName': 'T09 Glassy', 'SeedCropIndex': 92},
     200: {'Name': 'T09 Glassy Corn',        'Image': 't09-glassy-corn',         'SeedName': 'T09 Glassy', 'SeedCropIndex': 93},
-#T10 Glassy
+
+    #T10 Glassy
     201: {'Name': 'T10 Glassy Bananas',     'Image': 't10-glassy-bananas',      'SeedName': 'T10 Glassy', 'SeedCropIndex': 94},
     202: {'Name': 'T10 Glassy Mango',       'Image': 't10-glassy-mango',        'SeedName': 'T10 Glassy', 'SeedCropIndex': 95},
     203: {'Name': 'T10 Glassy Broccoli',    'Image': 't10-glassy-broccoli',     'SeedName': 'T10 Glassy', 'SeedCropIndex': 96},
@@ -8689,7 +8719,8 @@ cropDict = {
     208: {'Name': 'T10 Glassy Rose',        'Image': 't10-glassy-rose',         'SeedName': 'T10 Glassy', 'SeedCropIndex': 101},
     209: {'Name': 'T10 Glassy Onigiri',     'Image': 't10-glassy-corn',         'SeedName': 'T10 Glassy', 'SeedCropIndex': 102},
     210: {'Name': 'T10 Glassy Corn',        'Image': 't10-glassy-corn',         'SeedName': 'T10 Glassy', 'SeedCropIndex': 103},
-#T11 Glassy
+
+    #T11 Glassy
     211: {'Name': 'T11 Glassy Bananas',     'Image': 't11-glassy-bananas',      'SeedName': 'T11 Glassy', 'SeedCropIndex': 104},
     212: {'Name': 'T11 Glassy Mango',       'Image': 't11-glassy-mango',        'SeedName': 'T11 Glassy', 'SeedCropIndex': 105},
     213: {'Name': 'T11 Glassy Broccoli',    'Image': 't11-glassy-broccoli',     'SeedName': 'T11 Glassy', 'SeedCropIndex': 106},
@@ -8700,7 +8731,8 @@ cropDict = {
     218: {'Name': 'T11 Glassy Rose',        'Image': 't11-glassy-rose',         'SeedName': 'T11 Glassy', 'SeedCropIndex': 111},
     219: {'Name': 'T11 Glassy Onigiri',     'Image': 't11-glassy-corn',         'SeedName': 'T11 Glassy', 'SeedCropIndex': 112},
     220: {'Name': 'T11 Glassy Corn',        'Image': 't11-glassy-corn',         'SeedName': 'T11 Glassy', 'SeedCropIndex': 113},
-#T12 Glassy
+
+    #T12 Glassy
     221: {'Name': 'T12 Glassy Bananas',     'Image': 't12-glassy-bananas',      'SeedName': 'T12 Glassy', 'SeedCropIndex': 114},
     222: {'Name': 'T12 Glassy Mango',       'Image': 't12-glassy-mango',        'SeedName': 'T12 Glassy', 'SeedCropIndex': 115},
     223: {'Name': 'T12 Glassy Broccoli',    'Image': 't12-glassy-broccoli',     'SeedName': 'T12 Glassy', 'SeedCropIndex': 116},
@@ -8736,7 +8768,6 @@ def getCropEvoChance(overallSeedNumber: int) -> float:
 
 def getRequiredCropNumber(upgrade, target_level):
     target_index = target_level - 1  #Formula uses the number of already purchased levels: x - 1
-    result_number = 0
     match upgrade:
         case 'Land Plots':
             starting_value = 0
@@ -9318,6 +9349,7 @@ def decode_enemy_name(coded_name: str) -> str:
     if decoded_name.startswith('Unknown'):
         logger.warning(f"Unknown enemy code name: {coded_name}")
     return decoded_name
+
 
 ###SLAB CONSTS###
 #SlabItemSort last pulled from code in v2.35 Wind Walker class
@@ -10453,6 +10485,7 @@ def find_vendor_name(item_codename):
     for vendor_name, sold_items in vendorItems.items():
         if item_codename in sold_items:
             return vendor_name
+
 
 #anvilItems last pulled from code in 2.12. Search for: ItemToCraftNAME = function ()
 anvilItems = {

--- a/mysite/general/pinchy.py
+++ b/mysite/general/pinchy.py
@@ -187,7 +187,7 @@ class Placements(dict):
         ACHIEVEMENTS:  [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      1,  1,  1,      1,  2,  3,      4,     true_max_tiers[ACHIEVEMENTS], 99],
         GSTACKS:       [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  0,  0,      1,  2,  2,      2,  3,  3,      3,     true_max_tiers[GSTACKS], 99],
         Q_GSTACKS:     [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      0,  0,  0,      0,  0,  0,      0,  0,  0,      0,     true_max_tiers[Q_GSTACKS], 99],
-        VAULT:         [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      2,  2,  2,      3,  3,  3,      3,     true_max_tiers[VAULT], 99],
+        VAULT:         [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      2,  2,  2,      2,  3,  3,      3,     true_max_tiers[VAULT], 99],
         STAMPS:        [0,   1, 2, 2,    3,  4,  5,      6,  7,  8,      9, 10, 11,     12, 13, 14,     15, 16, 17,     20,    true_max_tiers[STAMPS], 99],
         BRIBES:        [0,   1, 1, 1,    2,  2,  2,      3,  3,  3,      4,  4,  4,      4,  5,  5,      5,  5,  5,      6,     true_max_tiers[BRIBES], 99],
         SMITHING:      [0,   0, 0, 0,    0,  0,  0,      0,  0,  0,      1,  1,  1,      1,  2,  2,      3,  4,  5,      6,     true_max_tiers[SMITHING], 99],

--- a/mysite/models/account_calcs.py
+++ b/mysite/models/account_calcs.py
@@ -1,4 +1,3 @@
-import copy
 from math import ceil, floor, log2, prod
 from consts import (
     # General
@@ -679,7 +678,7 @@ def _calculate_w1_owl_bonuses(account):
             'BaseValue': bonus_base,
             'NumUnlocked': bonus_num_unlocked,
             'Value': safer_convert(bonus_value, 0)
-    }
+        }
 
 
 def _calculate_w2(account):
@@ -1419,7 +1418,8 @@ def _calculate_caverns_motherlode_layers(account):
 def _calculate_caverns_monuments_bravery(account):
     monument_name = 'Bravery Monument'
     account.caverns['Caverns'][monument_name]['Sword Count'] = (
-        min(9,
+        min(
+            9,
             3  # Starting amount
             + (2 * (account.caverns['Caverns'][monument_name]['Hours'] >= 80))
             + (1 * (account.caverns['Caverns'][monument_name]['Hours'] >= 750))

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,13 +7,13 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-05-19: TBD
+        Beta testing: 2025-05-26: WIP- Changing Info Tiers to Optional Tiers, adding Optional filter
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}
     </p>
     <p>
-        Latest Update 2025-05-19: New Drop Rate section + Death Note and Atom Collider Tier changes
+        Latest Update 2025-05-25: Vault T3 fix, Alchemy T7-9 tweaks, Breeding T13-15 added
     </p>
     <form action="/" method="POST">
         <div id="switchbox-wrapper">

--- a/mysite/w1/upgrade_vault.py
+++ b/mysite/w1/upgrade_vault.py
@@ -15,7 +15,7 @@ def getProgressionTiersAdviceGroup() -> tuple[AdviceGroup, int, int]:
     vault_AdviceDict = {
         'Tiers': {},
     }
-    info_tiers = 1
+    info_tiers = 0
     true_max = max(vault_progressionTiers.keys(), default=0)
     max_tier = true_max - info_tiers
     tier_Vault = 0

--- a/mysite/w3/consDeathNote.py
+++ b/mysite/w3/consDeathNote.py
@@ -275,8 +275,9 @@ def getDeathNoteProgressionTiersAdviceGroup():
     if highestZOWCountIndex is not None:
         deathnote_AdviceGroupDict['ZOW'] = AdviceGroup(
             tier=str(tier_combo['ZOW'] if tier_combo['ZOW'] < max_tier else ""),
-            pre_string=f"{'Informational- You could complete' if tier_combo['ZOW'] >= max_tier else 'Complete'} {apocToNextTier['ZOW']} more"
-                       f" ZOW{pl(apocToNextTier['ZOW'])} with {session_data.account.all_characters[highestZOWCountIndex].character_name} {zowsForNextTier}",
+            pre_string=f"""{f"Informational Tier {tier_combo['ZOW']}- You could complete" if tier_combo['ZOW'] >= max_tier else 'Complete'} """
+                       f"""{apocToNextTier['ZOW']} more ZOW{pl(apocToNextTier['ZOW'])} with """
+                       f"""{session_data.account.all_characters[highestZOWCountIndex].character_name} {zowsForNextTier}""",
             advices=deathnote_AdviceDict['ZOW'],
             post_string="Aim for 12hrs or less (8k+ KPH) per enemy",
             informational=True if tier_combo['ZOW'] >= max_tier else False
@@ -292,8 +293,9 @@ def getDeathNoteProgressionTiersAdviceGroup():
     if highestCHOWCountIndex is not None:
         deathnote_AdviceGroupDict['CHOW'] = AdviceGroup(
             tier=str(tier_combo['CHOW'] if tier_combo['CHOW'] < max_tier else ""),
-            pre_string=f"{'Informational- You could complete' if tier_combo['CHOW'] >= max_tier else 'Complete'} {apocToNextTier['CHOW']} more"
-                       f" CHOW{pl(apocToNextTier['CHOW'])} with {session_data.account.all_characters[highestCHOWCountIndex].character_name} {chowsForNextTier}",
+            pre_string=f"""{f"Informational Tier {tier_combo['CHOW']}- You could complete" if tier_combo['CHOW'] >= max_tier else 'Complete'} """
+                       f"""{apocToNextTier['CHOW']} more CHOW{pl(apocToNextTier['CHOW'])} with """
+                       f"""{session_data.account.all_characters[highestCHOWCountIndex].character_name} {chowsForNextTier}""",
             advices=deathnote_AdviceDict['CHOW'],
             post_string="Aim for 12hrs or less (83k+ KPH) per enemy",
             informational=True if tier_combo['CHOW'] >= max_tier else False
@@ -309,8 +311,9 @@ def getDeathNoteProgressionTiersAdviceGroup():
     if apocalypse_character_Index is not None:
         deathnote_AdviceGroupDict['MEOW'] = AdviceGroup(
             tier=str(tier_combo['MEOW'] if tier_combo['MEOW'] < max_tier else ""),
-            pre_string=f"{'Informational- You could complete' if tier_combo['MEOW'] >= max_tier else 'Complete'} {apocToNextTier['MEOW']} more"
-                       f" Super CHOW{pl(apocToNextTier['MEOW'])} with {session_data.account.all_characters[apocalypse_character_Index].character_name} {meowsForNextTier}",
+            pre_string=f"""{f"Informational Tier {tier_combo['MEOW']}- You could complete" if tier_combo['MEOW'] >= max_tier else 'Complete'} """
+                       f"""{apocToNextTier['MEOW']} more Super CHOW{pl(apocToNextTier['MEOW'])} with """
+                       f"""{session_data.account.all_characters[apocalypse_character_Index].character_name} {meowsForNextTier}""",
             advices=deathnote_AdviceDict['MEOW'],
             post_string=f"Aim for 24hrs or less (4m+ KPH) per enemy",
             informational=True if tier_combo['MEOW'] >= max_tier else False
@@ -326,8 +329,9 @@ def getDeathNoteProgressionTiersAdviceGroup():
     if apocalypse_character_Index is not None:
         deathnote_AdviceGroupDict['WOW'] = AdviceGroup(
             tier=str(tier_combo['WOW'] if tier_combo['WOW'] < max_tier else ""),
-            pre_string=f"{'Informational- You could complete' if tier_combo['WOW'] >= max_tier else 'Complete'} {apocToNextTier['WOW']} more"
-                       f" WOW{pl(apocToNextTier['WOW'])} with {session_data.account.all_characters[apocalypse_character_Index].character_name} {wowsForNextTier}",
+            pre_string=f"""{f"Informational Tier {tier_combo['WOW']}- You could complete" if tier_combo['WOW'] >= max_tier else 'Complete'} """
+                       f"""{apocToNextTier['WOW']} more WOW{pl(apocToNextTier['WOW'])} with """
+                       f"""{session_data.account.all_characters[apocalypse_character_Index].character_name} {wowsForNextTier}""",
             advices=deathnote_AdviceDict['WOW'],
             post_string='Aim for 10m+ KPH per enemy',
             informational=True if tier_combo['WOW'] >= max_tier else False


### PR DESCRIPTION
* Breeding Max Shiny info tiers

* Address IDE formatting complaints

* Bubble + Vault Tier tweaks

### Vault
* Card Retirement is now optional.
* Bugfix: Tier 3 is no longer marked incorrectly as Informational/Optional
* Tier 3 also reduced from Early W7 to Solid W7 Prep placement

## Alchemy Bubbles
### Tier 6
* Purple: Tree Sleeper - 94 (Worship - Purple Souls)
  * First appearance now in Tier 7 at 160 ### Tier 7
* Orange: Dream of Ironfish - 120 (Anvil - Tangled Wire)
  * First appearance now in Tier 8 at level 170
* Green: Premigreen - 120 (Trapping - Dung Beets)
  * First appearance now in Tier 8 at level 170 ### Tier 9
* Orange: Shimmeron - 360 (Anvil - PVC Pipe)
  * No longer appears in any required Tiers ### Optional Tier 15
* Orange: Shimmeron - 3960 (Anvil - PVC Pipe)
  * No longer appears in this section as a whole actually. DB/Ribbons really demolished this being useful at all.

* Beta patch notes

* Display Info Tier # for Death Note

* PROD patch notes