### PR TITLE
Deathnote requirement delay logic

### DIFF
--- a/changelog/CHANGELOG
+++ b/changelog/CHANGELOG
@@ -1,3 +1,4 @@
+2025-09-19: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
 2025-09-15: Improvements to the Drop Rate section and various bugfixes
 2025-09-13: Performance improvements for iPhones
 2025-07-26: More patch changes from 2.38, 2.40, 2.41. Not totally caught up yet.

--- a/mysite/consts/consts_w3.py
+++ b/mysite/consts/consts_w3.py
@@ -917,7 +917,7 @@ apocable_map_index_dict = {
 dn_basic_maps_count = sum([len(v) for k, v in apocable_map_index_dict.items() if k > 0])
 dn_all_apoc_maps_count = dn_basic_maps_count + len(apocable_map_index_dict[0])
 apoc_amounts_list = [100000, 1000000, 100000000, 1000000000, 1000000000000]
-apoc_names_list = ["ZOW", "CHOW", "MEOW", "WOW", "64bitOverflow"]
+apoc_names_list = ["ZOW", "CHOW", "MEOW", "WOW", "Unfiltered"]
 apoc_difficulty_name_list = [
     'Basic W1 Enemies', 'Basic W2 Enemies', 'Basic W3 Enemies', 'Basic W4 Enemies', 'Basic W5 Enemies', 'Basic W6 Enemies',
     'Easy Extras', 'Medium Extras', 'Difficult Extras', 'Insane', 'Impossible'

--- a/mysite/consts/consts_w3.py
+++ b/mysite/consts/consts_w3.py
@@ -884,37 +884,30 @@ approx_max_talent_level_es = approx_max_talent_level_non_es + 4  # Family Guy
 dn_skull_requirement_list = [0, 25000, 100000, 250000, 500000, 1000000, 5000000, 100000000, 1000000000]
 dn_miniboss_skull_requirement_list = [0, 100, 250, 1000, 5000, 25000, 100000, 1000000, 1000000000]
 dn_skull_value_list = [0, 1, 2, 3, 4, 5, 7, 10, 20]
+dn_skull_names = [
+    'None',
+    'Normal Skull',
+    'Copper Skull',
+    'Iron Skull',
+    'Gold Skull',
+    'Platinum Skull',
+    'Dementia Skull',
+    'Lava Skull',
+    'Eclipse Skull',
+]
+dn_skull_value_to_name_dict = dict(zip(dn_skull_value_list, dn_skull_names))
+dn_skull_name_to_requirement_normal = dict(zip(dn_skull_names, dn_skull_requirement_list))
+dn_skull_name_to_requirement_miniboss = dict(zip(dn_skull_names, dn_miniboss_skull_requirement_list))
 dn_miniboss_names = [
     'Glunko The Massive', 'Dr Defecaus', 'Baba Yaga', 'Biggie Hours', 'King Doot',
     'Dilapidated Slush', 'Mutated Mush', 'Domeo Magmus', 'Demented Spiritlord'
 ]
 reversed_dn_skull_requirement_list = dn_skull_requirement_list[::-1]
 reversed_dn_skull_value_list = dn_skull_value_list[::-1]
-dn_skull_value_to_name_dict = {
-    0: "None",
-    1: "Normal Skull",
-    2: "Copper Skull",
-    3: "Iron Skull",
-    4: "Gold Skull",
-    5: "Platinum Skull",
-    7: "Dementia Skull",
-    10: "Lava Skull",
-    20: "Eclipse Skull"
-}
-dn_next_skull_name_dict = {
-    0: "Normal Skull",
-    1: "Copper Skull",
-    2: "Iron Skull",
-    3: "Gold Skull",
-    4: "Platinum Skull",
-    5: "Dementia Skull",
-    7: "Lava Skull",
-    10: "Eclipse Skull",
-    20: "Finished!"
-}
+
 apocable_map_index_dict = {
-    0: [31, 30, 9, 38, 69, 120, 166],  # Barbarian only, not in regular DeathNote
-    1: [1, 2, 14, 17, 16, 13, 18, 19, 24, 26, 27, 28, 8, 15],  # MapIndex 31 for Brown Mushrooms was moved into 0 because they're very slow
+    0: [30, 9, 38, 69, 120, 166],  # Barbarian only, not in regular DeathNote
+    1: [1, 2, 14, 17, 16, 13, 18, 19, 24, 26, 27, 28, 8, 15, 31],
     2: [51, 52, 53, 57, 58, 59, 60, 62, 63, 64, 65],
     3: [101, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 116, 117],
     4: [151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163],
@@ -929,6 +922,17 @@ apoc_difficulty_name_list = [
     'Basic W1 Enemies', 'Basic W2 Enemies', 'Basic W3 Enemies', 'Basic W4 Enemies', 'Basic W5 Enemies', 'Basic W6 Enemies',
     'Easy Extras', 'Medium Extras', 'Difficult Extras', 'Insane', 'Impossible'
 ]
+dn_delays = {
+    # DelayUntilTier allows a monster map to be skipped until a particular tier
+    # DelayUntilSkull allows a monster map to be skipped until the tier requires a particular Skull value, i.e. 20 for Eclipse Skull
+    #W1
+    'Where the Branches End': {'DelayUntilTier': 22},
+    #W6
+    'Yolkrock Basin': {'DelayUntilSkull': dn_skull_value_list[7]},
+    'Chieftain Stairway': {'DelayUntilSkull': dn_skull_value_list[7]},
+    "Emperor's Castle Doorstep": {'DelayUntilSkull': dn_skull_value_list[8]}
+}
+
 max_trapping_critter_types = 12
 trapping_quests_requirement_list = [
     {"QuestName": "Frogecoin to the MOON!", 'RequiredItems': {"Critter1": 100, "Critter1A": 1}},
@@ -963,10 +967,13 @@ def getSkullNames(mkValue: int) -> str:
 
 
 def getNextSkullNames(mkValue: int) -> str:
-    try:
-        return dn_next_skull_name_dict.get(mkValue, f"UnknownSkull{mkValue}")
-    except Exception as reason:
-        return f"Unexpected Input received: {reason}"
+    if mkValue == dn_skull_value_list[-1]:
+        return "Finished!"
+    else:
+        try:
+            return dn_skull_names[dn_skull_value_list.index(mkValue) + 1]
+        except Exception as reason:
+            return f"Unexpected Input '{mkValue}' received: {reason}"
 
 
 def getEnemyNameFromMap(inputMap: str) -> str:
@@ -1073,6 +1080,23 @@ def getEnemyNameFromMap(inputMap: str) -> str:
         return mapNametoEnemyNameDict.get(inputMap, f"UnknownMap:{inputMap}")
     except Exception as reason:
         return f"Unexpected Input received: {reason}"
+
+
+def getDNKillRequirement(miniboss=False, skull_value=None, skull_name=''):
+    required_kills = 0
+    if skull_value is not None:
+        required_kills = (
+            dn_skull_requirement_list[dn_skull_value_list.index(skull_value)]
+            if miniboss is False else
+            dn_miniboss_skull_requirement_list[dn_skull_value_list.index(skull_value)]
+        )
+    elif skull_name != '':
+        required_kills = (
+            dn_skull_name_to_requirement_normal[skull_name]
+            if miniboss is False else
+            dn_skull_name_to_requirement_miniboss[skull_name]
+        )
+    return required_kills
 
 
 printer_indexes_being_printed_by_character_index = [

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -1637,8 +1637,9 @@ def _parse_w3_deathnote_kills(account):
                                 account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apocIndex]),
                                 [
                                     account.enemy_maps[worldIndex][enemy_map].map_name,  # map name
-                                    apocAmount - kill_count if apocIndex < 3 else kill_count,  # kills short of zow/chow/meow
-                                    floor((kill_count / apocAmount) * 100),  # percent toward zow/chow/meow
+                                    apocAmount - kill_count if apocIndex < len(apoc_amounts_list) else kill_count,  # kills short of Apoc stack
+                                    # Note: The final entry in apoc_amounts_list is a placeholder used for the unfiltered display with no goal
+                                    min(99, floor(round((kill_count / apocAmount) * 100))),  # percent toward Apoc stack
                                     account.enemy_maps[worldIndex][enemy_map].monster_image,  # monster image
                                     worldIndex
                                 ]

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -1629,32 +1629,32 @@ def _parse_w3_deathnote_kills(account):
             for enemy_map in account.enemy_maps[worldIndex]:
                 if barbCharacterIndex in account.enemy_maps[worldIndex][enemy_map].zow_dict:
                     kill_count = account.enemy_maps[worldIndex][enemy_map].zow_dict[barbCharacterIndex]
-                    for apocIndex, apocAmount in enumerate(apoc_amounts_list):
-                        if kill_count < apocAmount:
-                            # characterDict[barbCharacterIndex].apoc_dict[apoc_names_list[apocIndex]][enemyMaps[worldIndex][enemy_map].zow_rating].append([
+                    for apoc_index, apoc_amount in enumerate(apoc_amounts_list):
+                        if kill_count < apoc_amount:
+                            # characterDict[barbCharacterIndex].apoc_dict[apoc_names_list[apoc_index]][enemyMaps[worldIndex][enemy_map].zow_rating].append([
                             account.all_characters[barbCharacterIndex].addUnmetApoc(
-                                apoc_names_list[apocIndex],
-                                account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apocIndex]),
+                                apoc_names_list[apoc_index],
+                                account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apoc_index]),
                                 [
                                     account.enemy_maps[worldIndex][enemy_map].map_name,  # map name
-                                    apocAmount - kill_count if apocIndex < len(apoc_amounts_list) else kill_count,  # kills short of Apoc stack
+                                    apoc_amount - kill_count if apoc_index < len(apoc_amounts_list) - 1 else kill_count,  # kills short of Apoc stack
                                     # Note: The final entry in apoc_amounts_list is a placeholder used for the unfiltered display with no goal
-                                    min(99, floor(round((kill_count / apocAmount) * 100))),  # percent toward Apoc stack
+                                    min(99, floor(round((kill_count / apoc_amount) * 100))),  # percent toward Apoc stack
                                     account.enemy_maps[worldIndex][enemy_map].monster_image,  # monster image
                                     worldIndex
                                 ]
                             )
                         else:
-                            account.all_characters[barbCharacterIndex].increaseApocTotal(apoc_names_list[apocIndex])
+                            account.all_characters[barbCharacterIndex].increaseApocTotal(apoc_names_list[apoc_index])
                 else:
                     # This condition can be hit when reviewing data from before a World release
                     # For example, JSON data from w5 before w6 is released hits this to populate 0% toward W6 kills
-                    for apocIndex, apocAmount in enumerate(apoc_amounts_list):
+                    for apoc_index, apoc_amount in enumerate(apoc_amounts_list):
                         account.all_characters[barbCharacterIndex].addUnmetApoc(
-                            apoc_names_list[apocIndex], account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apocIndex]),
+                            apoc_names_list[apoc_index], account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apoc_index]),
                             [
                                 account.enemy_maps[worldIndex][enemy_map].map_name,  # map name
-                                apoc_amounts_list[apocIndex],  # kills short of zow/chow/meow
+                                apoc_amounts_list[apoc_index],  # kills short of zow/chow/meow
                                 0,  # percent toward zow/chow/meow
                                 account.enemy_maps[worldIndex][enemy_map].monster_image,  # monster image
                                 worldIndex

--- a/mysite/models/models.py
+++ b/mysite/models/models.py
@@ -1559,7 +1559,7 @@ class EnemyMap:
             for skullValueIndex in range(1, len(reversed_dn_skull_value_list)):
                 if self.skull_mk_value == reversed_dn_skull_value_list[skullValueIndex]:
                     self.kills_to_next_skull = ceil(reversed_dn_skull_requirement_list[skullValueIndex - 1] - self.kill_count)
-                    self.percent_toward_next_skull = floor((self.kill_count / reversed_dn_skull_requirement_list[skullValueIndex - 1]) * 100)
+                    self.percent_toward_next_skull = floor(round(self.kill_count / reversed_dn_skull_requirement_list[skullValueIndex - 1] * 100))
 
 def buildMaps() -> dict[int, dict]:
     mapDict = {

--- a/mysite/models/models.py
+++ b/mysite/models/models.py
@@ -1468,7 +1468,9 @@ class EnemyWorld:
                     [self.maps_dict[enemy_map_index].map_name,
                      self.maps_dict[enemy_map_index].kills_to_next_skull,
                      self.maps_dict[enemy_map_index].percent_toward_next_skull,
-                     self.maps_dict[enemy_map_index].monster_image])
+                     self.maps_dict[enemy_map_index].monster_image,
+                     self.maps_dict[enemy_map_index].kill_count],
+                )
             for skullDict in self.lowest_skulls_dict:
                 self.lowest_skulls_dict[skullDict] = sorted(self.lowest_skulls_dict[skullDict], key=lambda item: item[2], reverse=True)
             for skullDict in self.lowest_skulls_dict:

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,13 +7,13 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-09-17: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
+        Beta testing: 2025-09-19: Fixing misc rounding issues, Relic Chains in Drop Rate section, and Emperor W7ish bonuses
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}
     </p>
     <p>
-        Latest Update 2025-09-15: Improvements to the Drop Rate section and various bugfixes
+        Latest Update 2025-09-19: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
     </p>
     <form action="/" method="POST">
         <div id="switchbox-wrapper">

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,7 +7,7 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-09-15: TBD
+        Beta testing: 2025-09-17: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}

--- a/mysite/w3/death_note.py
+++ b/mysite/w3/death_note.py
@@ -1,3 +1,4 @@
+from math import floor
 from consts.consts_autoreview import break_you_best
 from consts.consts_general import current_world
 from consts.consts_w3 import apoc_names_list, apoc_difficulty_name_list, dn_delays, dn_skull_value_to_name_dict, getDNKillRequirement
@@ -14,7 +15,7 @@ logger = get_logger(__name__)
 def getAllKillsDisplaySubgroupedByWorldAdviceGroup():
     advices = {}
     ags = []
-    apoc_name = apoc_names_list[-1]
+    apoc_name = apoc_names_list[-1]  #This is the Unfiltered placeholder that stores just kill_count without any goal
     difficulty_name = apoc_difficulty_name_list[-2]
     #logger.debug(f"apocCharactersIndexList: {session_data.account.apocCharactersIndexList}")
     for character_index in session_data.account.apocCharactersIndexList:
@@ -138,7 +139,10 @@ def getDeathNoteProgressionTiersAdviceGroup():
                 else:
                     required_kills = getDNKillRequirement(skull_value=tier[world_index])
                     for skull_value in full_death_note_dict[world_index].lowest_skulls_dict:
+                        skull_name = dn_skull_value_to_name_dict[skull_value]
                         if skull_value < tier[world_index]:
+                            # Looking for previously skipped enemy requirements where {skull_value} < {tier[world_index]}
+                            # I promise this should be < not <=. You'll get negative amounts remaining if you use <=
                             for enemy in full_death_note_dict[world_index].lowest_skulls_dict[skull_value]:
                                 if (
                                     tier[world_index] < dn_delays.get(enemy[0], {}).get('DelayUntilSkull', 0)
@@ -155,13 +159,13 @@ def getDeathNoteProgressionTiersAdviceGroup():
                                             f"{enemy[0]} ({notateNumber('Basic', required_kills - enemy[4], 0)} remaining)"
                                         ),
                                         picture_class=enemy[3],
-                                        progression=enemy[2],
+                                        progression=min(99, floor(round(enemy[4]/required_kills * 100))),  #enemy[2]
                                         goal=100,
-                                        unit='%'
+                                        unit='%',
+                                        resource=skull_name
                                     ))
-
+                    # After checking every rele
                     if len(deathnote_AdviceDict[f'W{world_index}']) == 0:
-                        # logger.debug(f"Pass: W{world_index} requirement{pl(full_death_note_dict[world_index].lowest_skulls_dict[full_death_note_dict[world_index].lowest_skull_value])} delayed in T{tier[0]}")
                         tier_combo[world_index] = tier[0]
 
         # ZOW

--- a/mysite/w3/death_note.py
+++ b/mysite/w3/death_note.py
@@ -164,7 +164,7 @@ def getDeathNoteProgressionTiersAdviceGroup():
                                         unit='%',
                                         resource=skull_name
                                     ))
-                    # After checking every rele
+                    # If all failed requirements were delayed, be sure to increase the Tier as this counts as a Pass
                     if len(deathnote_AdviceDict[f'W{world_index}']) == 0:
                         tier_combo[world_index] = tier[0]
 


### PR DESCRIPTION
* Placed MapIndex 31 for Wood Mushrooms back into W1 instead of W0/Apoc Only
* Added getDNKillRequirement() to find kill count required from either skull value or name
* Added dn_delays to store Maps which should be delayed until a certain Skull value or Tier
  * W1 Wood Mushrooms delayed until T22
  * W6 Royal Egg delayed until Lava Skull
  * W6 Minichief Spirit delayed until Lava Skull
  * W6 Samurai Guardians delayed until Eclipse Skull
* Reworded each World-specific AG pre_string to include Kill Count Requirement for that Skull
* Added remaining kills to each monster advice