### PR TITLE
Deathnote requirement delay logic (#347)

### DIFF
--- a/changelog/CHANGELOG
+++ b/changelog/CHANGELOG
@@ -1,3 +1,4 @@
+2025-09-19: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
 2025-09-15: Improvements to the Drop Rate section and various bugfixes
 2025-09-13: Performance improvements for iPhones
 2025-07-26: More patch changes from 2.38, 2.40, 2.41. Not totally caught up yet.

--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -1629,31 +1629,32 @@ def _parse_w3_deathnote_kills(account):
             for enemy_map in account.enemy_maps[worldIndex]:
                 if barbCharacterIndex in account.enemy_maps[worldIndex][enemy_map].zow_dict:
                     kill_count = account.enemy_maps[worldIndex][enemy_map].zow_dict[barbCharacterIndex]
-                    for apocIndex, apocAmount in enumerate(apoc_amounts_list):
-                        if kill_count < apocAmount:
-                            # characterDict[barbCharacterIndex].apoc_dict[apoc_names_list[apocIndex]][enemyMaps[worldIndex][enemy_map].zow_rating].append([
+                    for apoc_index, apoc_amount in enumerate(apoc_amounts_list):
+                        if kill_count < apoc_amount:
+                            # characterDict[barbCharacterIndex].apoc_dict[apoc_names_list[apoc_index]][enemyMaps[worldIndex][enemy_map].zow_rating].append([
                             account.all_characters[barbCharacterIndex].addUnmetApoc(
-                                apoc_names_list[apocIndex],
-                                account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apocIndex]),
+                                apoc_names_list[apoc_index],
+                                account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apoc_index]),
                                 [
                                     account.enemy_maps[worldIndex][enemy_map].map_name,  # map name
-                                    apocAmount - kill_count if apocIndex < 3 else kill_count,  # kills short of zow/chow/meow
-                                    floor((kill_count / apocAmount) * 100),  # percent toward zow/chow/meow
+                                    apoc_amount - kill_count if apoc_index < len(apoc_amounts_list) - 1 else kill_count,  # kills short of Apoc stack
+                                    # Note: The final entry in apoc_amounts_list is a placeholder used for the unfiltered display with no goal
+                                    min(99, floor(round((kill_count / apoc_amount) * 100))),  # percent toward Apoc stack
                                     account.enemy_maps[worldIndex][enemy_map].monster_image,  # monster image
                                     worldIndex
                                 ]
                             )
                         else:
-                            account.all_characters[barbCharacterIndex].increaseApocTotal(apoc_names_list[apocIndex])
+                            account.all_characters[barbCharacterIndex].increaseApocTotal(apoc_names_list[apoc_index])
                 else:
                     # This condition can be hit when reviewing data from before a World release
                     # For example, JSON data from w5 before w6 is released hits this to populate 0% toward W6 kills
-                    for apocIndex, apocAmount in enumerate(apoc_amounts_list):
+                    for apoc_index, apoc_amount in enumerate(apoc_amounts_list):
                         account.all_characters[barbCharacterIndex].addUnmetApoc(
-                            apoc_names_list[apocIndex], account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apocIndex]),
+                            apoc_names_list[apoc_index], account.enemy_maps[worldIndex][enemy_map].getRating(apoc_names_list[apoc_index]),
                             [
                                 account.enemy_maps[worldIndex][enemy_map].map_name,  # map name
-                                apoc_amounts_list[apocIndex],  # kills short of zow/chow/meow
+                                apoc_amounts_list[apoc_index],  # kills short of zow/chow/meow
                                 0,  # percent toward zow/chow/meow
                                 account.enemy_maps[worldIndex][enemy_map].monster_image,  # monster image
                                 worldIndex

--- a/mysite/models/models.py
+++ b/mysite/models/models.py
@@ -1468,7 +1468,9 @@ class EnemyWorld:
                     [self.maps_dict[enemy_map_index].map_name,
                      self.maps_dict[enemy_map_index].kills_to_next_skull,
                      self.maps_dict[enemy_map_index].percent_toward_next_skull,
-                     self.maps_dict[enemy_map_index].monster_image])
+                     self.maps_dict[enemy_map_index].monster_image,
+                     self.maps_dict[enemy_map_index].kill_count],
+                )
             for skullDict in self.lowest_skulls_dict:
                 self.lowest_skulls_dict[skullDict] = sorted(self.lowest_skulls_dict[skullDict], key=lambda item: item[2], reverse=True)
             for skullDict in self.lowest_skulls_dict:
@@ -1557,7 +1559,7 @@ class EnemyMap:
             for skullValueIndex in range(1, len(reversed_dn_skull_value_list)):
                 if self.skull_mk_value == reversed_dn_skull_value_list[skullValueIndex]:
                     self.kills_to_next_skull = ceil(reversed_dn_skull_requirement_list[skullValueIndex - 1] - self.kill_count)
-                    self.percent_toward_next_skull = floor((self.kill_count / reversed_dn_skull_requirement_list[skullValueIndex - 1]) * 100)
+                    self.percent_toward_next_skull = floor(round(self.kill_count / reversed_dn_skull_requirement_list[skullValueIndex - 1] * 100))
 
 def buildMaps() -> dict[int, dict]:
     mapDict = {

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,13 +7,13 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2025-09-15: TBD
+        Beta testing: 2025-09-19: Fixing misc rounding issues, Relic Chains in Drop Rate section, and Emperor W7ish bonuses
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}
     </p>
     <p>
-        Latest Update 2025-09-15: Improvements to the Drop Rate section and various bugfixes
+        Latest Update 2025-09-19: Deathnote remaining kills display, requirement changes for Brown Mushrooms + last quarter of W6
     </p>
     <form action="/" method="POST">
         <div id="switchbox-wrapper">


### PR DESCRIPTION
* Deathnote requirement delay logic

* Placed MapIndex 31 for Wood Mushrooms back into W1 instead of W0/Apoc Only
* Added getDNKillRequirement() to find kill count required from either skull value or name
* Added dn_delays to store Maps which should be delayed until a certain Skull value or Tier
  * W1 Wood Mushrooms delayed until T22
  * W6 Royal Egg delayed until Lava Skull
  * W6 Minichief Spirit delayed until Lava Skull
  * W6 Samurai Guardians delayed until Eclipse Skull
* Reworded each World-specific AG pre_string to include Kill Count Requirement for that Skull
* Added remaining kills to each monster advice

* BETA Patch notes

* Bugfixes + Resource image

* Added player's current obtained skull as the resource image to world-specific advices
* Fix WOWs storing raw kill count instead of `requirement - kill count` within account.enemy_maps
* Fixed progression to use new calculation using the Tier's target for the Prog% instead of the Prog% toward the Enemy's next skull requirement. This was highlighted due to W6 having a DN Tier that goes up by more than 1 skull at a time

* Fix unfiltered conditional

* Fix inaccurate conditional to allow the unfiltered "apoc" to only store kill_count. Should have been len()-1 since I'm comparing it with a 0-based index

* Fix comment

* PROD Patch notes