### PR TITLE
fixed uv sync issues with pyproject.toml and uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "idleonautoreviewbot"
 version = "0.1.0"
 description = "Add your description here"
-requires-python = "3.10"
+requires-python = "==3.10"
 dependencies = [
     "babel==2.17.0",
     "coloredlogs==15.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = "3.10"
+requires-python = "==3.10"
 
 [[package]]
 name = "babel"


### PR DESCRIPTION
When pulling repo and using `uv venv --python 3.10` I got error
<img width="987" height="195" alt="изображение" src="https://github.com/user-attachments/assets/c05b98b3-aaaf-4cd1-a18d-c7e1438577b6" />

Same error fixed for uv.lock file

```
uv --version
uv 0.9.5 (d5f39331a 2025-10-21)
```
