### PR TITLE
Remove SilverPen from filter_never

### DIFF
--- a/mysite/consts/consts_w5.py
+++ b/mysite/consts/consts_w5.py
@@ -1512,7 +1512,7 @@ filter_never = [
     #Consumables
     'PremiumGem', 'Quest71', 'ExpBalloon1', 'ExpBalloon2', 'ExpBalloon3',
     'Timecandy1', 'Timecandy2', 'Timecandy3', 'Timecandy4', 'Timecandy5', 'Timecandy6', 'Timecandy7', 'Timecandy8', 'Timecandy9', 'Timecandy10',
-    'SilverPen', 'PetEgg', 'Ladle',
+    'PetEgg', 'Ladle',
     'FoodEvent1', 'FoodEvent2', 'FoodEvent3', 'FoodEvent4', 'FoodEvent5', 'FoodEvent6', 'FoodEvent7', 'FoodEvent8',
     'Pearl1', 'Pearl2', 'Pearl3', 'Pearl4', 'Pearl5', 'Pearl6',
     'DungCredits1', 'DungCredits2',

--- a/mysite/consts/manage_consts.py
+++ b/mysite/consts/manage_consts.py
@@ -5,6 +5,7 @@
 from consts import consts_w2, progression_tiers
 from consts.consts_general import gstack_unique_expected, cardset_names, max_card_stars, greenstack_item_difficulty_groups, gstack_expected_not_rated
 from consts.consts_item_data import ITEM_DATA
+from consts.consts_w5 import filter_only_after_gstack, filter_never
 from consts.w1.stamps import unavailable_stamps_list, stamp_maxes
 from consts.consts_w2 import max_maxable_vials
 from consts.consts_w4 import get_final_combat_level_required_for_tome
@@ -18,6 +19,7 @@ def finalize_consts():
     finalize_general_combat_levels()
     finalize_w1_stamps()
     finalize_w2_vials()
+    finalize_w5_item_filters()
 
 def finalize_general_greenstacks():
     #Update consts_general.greenstack_item_difficulty_groups with a final group with all currently unclassified items
@@ -97,6 +99,7 @@ def finalize_w1_stamps():
     stamps_progressionTiers[max(stamps_progressionTiers)]['Stamps']['Specific'] = {stamp: stamp_maxes.get(stamp, 0) for stamp in remaining_stamps}
     logger.debug(f"Successfully updated Stamp Tier {max(stamps_progressionTiers)}")
 
+
 def finalize_w2_vials():
     try:
         assert max_maxable_vials == vials_progressionTiers[true_max_tiers['Vials']]['Maxed']
@@ -108,6 +111,11 @@ def finalize_w2_vials():
         )
         consts_w2.max_maxable_vials = max(max_maxable_vials, vials_progressionTiers[true_max_tiers['Vials']]['Maxed'])
         vials_progressionTiers[true_max_tiers['Vials']]['Maxed'] = max(max_maxable_vials, vials_progressionTiers[true_max_tiers['Vials']]['Maxed'])
+
+def finalize_w5_item_filters():
+    duplicate_entries = [entry for entry in filter_only_after_gstack if entry in filter_never]
+    if len(duplicate_entries) > 0:
+        logger.error(f"Duplicate consts_w5 filter entries found in filter_never and filter_only_after_gstack: {duplicate_entries}")
 
 
 finalize_consts()

--- a/mysite/templates/sidebar.html
+++ b/mysite/templates/sidebar.html
@@ -7,7 +7,7 @@
     {% if beta %}
         <strong>Heads up! You're on the beta-testing page. If you run into problems, try heading back to the <a href="{{ live_link }}" target="_blank">Live Page</a></strong>
         <br>
-        Beta testing: 2026-06-06: See Discord #beta-blog channel!
+        Beta testing: 2026-07-24: See Discord #beta-blog channel!
     {% else %}
         <strong>To try out the beta site, head to the <a href="{{ beta_link }}" target="_blank">Beta Page</a></strong>
     {% endif %}


### PR DESCRIPTION
SilverPen was present in both filter_never and filter_only_after_gstack, causing it to still create a priority alert.

To help catch any future accidents like this, I also added a function inside manage_consts to create an ERROR log on startup if any entries are duplicated between these 2 lists.