### PR TITLE
Fix cooking's Voidwalker condition to check for requirements

### DIFF
--- a/mysite/w4/cooking.py
+++ b/mysite/w4/cooking.py
@@ -57,7 +57,7 @@ def getCookingProgressionTiersAdviceGroups(highest_cooking_skill_level, cooking,
                 ))
 
         #Voidwalker created or troll/challenge account with no beginners
-        if len(vmans) == 0 and not challenge_account:
+        if requirements.get('Voidwalker', False) and len(vmans) == 0 and not challenge_account:
             add_subgroup_if_available_slot(cooking_Advices['Tiers'], subgroup_label)
             if subgroup_label in cooking_Advices['Tiers']:
                 cooking_Advices['Tiers'][subgroup_label].append(Advice(


### PR DESCRIPTION
The result is that the Voidman requirement is now only shown for tier 3, as intended.

Before (screenshot from live beta site):
<img width="726" height="552" alt="image" src="https://github.com/user-attachments/assets/9fa42f33-3d97-4b5b-9970-7bf7434e0b1d" />


After:
<img width="724" height="553" alt="image" src="https://github.com/user-attachments/assets/0116821b-e2f0-4799-b2cd-1ebdac20515d" />
