### PR TITLE
Fix Death Note Chow/Wow tracking to use last Deathbringer, not 2nd

### DIFF
--- a/mysite/models/account_parser.py
+++ b/mysite/models/account_parser.py
@@ -1776,10 +1776,10 @@ def _parse_w3_deathnote(account):
     _parse_w3_deathnote_miniboss_kills(account)
 
 def _parse_w3_apocalypse_BBIndex(account):
-    if len(account.bbCharactersIndexList) == 1:
-        return account.bbCharactersIndexList[0]
-    elif len(account.bbCharactersIndexList) >= 2:
-        return account.bbCharactersIndexList[1]
+    # Super CHOW/WOW progress is tracked on whichever Blood Berserker/Death Bringer
+    # is last in your character roster, not specifically your 2nd one.
+    if len(account.bbCharactersIndexList) >= 1:
+        return account.bbCharactersIndexList[-1]
     else:
         return None
 

--- a/mysite/w3/death_note.py
+++ b/mysite/w3/death_note.py
@@ -420,7 +420,7 @@ def getDeathNoteAdviceSection() -> AdviceSection:
         groups=deathnote_AdviceGroupDict.values(),
         note=(
             "Important! Since you already have 2+ Blood Berserkers, you must complete Super CHOWs and WOWs"
-            " with your 2nd regardless of the platform you play on."
+            " with the last one in your character roster, regardless of the platform you play on."
         ) if len(session_data.account.bbCharactersIndexList) > 1 else ''
     )
 


### PR DESCRIPTION
Chows, Super Chows, Wows and Zows are tracked against whichever Deathbringer/Blood Berserker is last in your character roster, not explicitly your 2nd one. Previously the tool always used the 2nd Blood Berserker's index, which is wrong for accounts with 3+ Deathbringers.

Also updated the in-app Death Note note text to reflect this.